### PR TITLE
Book With Me — free Calendly-style scheduling tool

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -40,14 +40,24 @@ jobs:
 
       - name: Deploy functions
         env:
-          ENVV: VAPID_PUBLIC=${{ secrets.VAPID_PUBLIC }},VAPID_PRIVATE=${{ secrets.VAPID_PRIVATE }},SENDER_SECRET=${{ secrets.SENDER_SECRET }}
+          # Prayer-alert vars + Book With Me vars (Google OAuth / Resend / Telegram).
+          # GOOGLE_OAUTH_CLIENT_ID is public (repo variable); the rest are secrets.
+          ENVV: VAPID_PUBLIC=${{ secrets.VAPID_PUBLIC }},VAPID_PRIVATE=${{ secrets.VAPID_PRIVATE }},SENDER_SECRET=${{ secrets.SENDER_SECRET }},GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }},GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }},RESEND_API_KEY=${{ secrets.RESEND_API_KEY }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
         run: |
           set -e
           common=(--gen2 --runtime=nodejs20 --region=us-central1 \
             --project="${{ vars.GCP_PROJECT }}" --source=. \
             --trigger-http --allow-unauthenticated --set-env-vars="$ENVV")
+          # Prayer alerts
           gcloud functions deploy subscribe   "${common[@]}" --entry-point=subscribe
           gcloud functions deploy unsubscribe "${common[@]}" --entry-point=unsubscribe
           gcloud functions deploy send-due    "${common[@]}" --entry-point=sendDue
           gcloud functions deploy touch       "${common[@]}" --entry-point=touch
           gcloud functions deploy debug       "${common[@]}" --entry-point=debug
+          # Book With Me — the callback name must match REDIRECT_URI in booking.js.
+          gcloud functions deploy booking-google-start    "${common[@]}" --entry-point=bookingGoogleStart
+          gcloud functions deploy booking-google-callback "${common[@]}" --entry-point=bookingGoogleCallback
+          gcloud functions deploy save-schedule           "${common[@]}" --entry-point=saveSchedule
+          gcloud functions deploy get-availability        "${common[@]}" --entry-point=getAvailability
+          gcloud functions deploy book                    "${common[@]}" --entry-point=book
+          gcloud functions deploy telegram-webhook        "${common[@]}" --entry-point=telegramWebhook

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 *.local
+.env
+.env.*
 .vite/
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,11 +177,25 @@ from the URL) to make that a config flip, not a rewrite. Trend home toward a
   **Ḍuḥā** (sunrise+20), and **morning/evening adhkār** (sunrise / Maghrib+15) — all
   additive `prefs` booleans; `subscribe` **merges** prefs so Prayer Times and Adhkar
   each own their toggles. See [`functions/README.md`](./functions/README.md).
+- **Book With Me backend** (`functions/booking.js`, same stack): Calendly-style
+  scheduling — `booking-google-start`/`-callback`, `save-schedule`,
+  `get-availability`, `book`, `telegram-webhook`. Firestore `bookingHosts` +
+  `bookings`. One Google OAuth flow signs the host in **and** grabs an offline
+  refresh token (calendar free/busy + auto-created events); host sessions are our
+  own HMAC token (`SENDER_SECRET`). No new npm deps — Google/Resend/Telegram over
+  `fetch`, hand-written `.ics`. Booking link is **path-based**
+  (`built-in-saudi.com/book/<code>`; subdomain deferred, no Cloudflare). On booking:
+  Web Push + Telegram DM (bot `@BuiltInSaudi_bot`) + Resend email w/ `.ics`. Extra
+  env: `GOOGLE_OAUTH_CLIENT_ID` (var), `GOOGLE_OAUTH_CLIENT_SECRET`/`RESEND_API_KEY`/
+  `TELEGRAM_BOT_TOKEN` (secrets). One-time `setWebhook` after deploy. See
+  [`docs/tools/book-with-me.md`](./docs/tools/book-with-me.md).
 - **Functions deploy = CI** (not manual gcloud): `.github/workflows/deploy-functions.yml`
-  deploys all five functions on any `functions/**` change, authenticating **keylessly
+  deploys all eleven functions on any `functions/**` change, authenticating **keylessly
   via Workload Identity Federation** (pool `github` in `blitz-ksa`, deploy SA
-  `gh-fn-deploy@…`). Repo vars `GCP_PROJECT`/`GCP_WIF_PROVIDER`/`GCP_DEPLOY_SA` +
-  repo secrets `VAPID_PUBLIC`/`VAPID_PRIVATE`/`SENDER_SECRET` feed it.
+  `gh-fn-deploy@…`). Repo vars `GCP_PROJECT`/`GCP_WIF_PROVIDER`/`GCP_DEPLOY_SA`/
+  `GOOGLE_OAUTH_CLIENT_ID`/`TELEGRAM_BOT_USERNAME` + repo secrets `VAPID_PUBLIC`/
+  `VAPID_PRIVATE`/`SENDER_SECRET`/`GOOGLE_OAUTH_CLIENT_SECRET`/`RESEND_API_KEY`/
+  `TELEGRAM_BOT_TOKEN` feed it.
 
 ## Roadmap
 

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -79,9 +79,10 @@ the box only for what the browser genuinely can't.
 > **Now being built** — this graduated from brainstorm to a real tool. Full
 > architecture, data model, endpoints and the external-setup checklist live in
 > [`tools/book-with-me.md`](./tools/book-with-me.md). Decisions locked: booking
-> page on a Cloudflare Pages **subdomain** (`book-a-meeting.built-in-saudi.com/<code>`),
-> **full Google Calendar sync** (free/busy + auto-create events), **Resend** for
-> email + `.ics`, plus Web Push + Telegram DM on booking. Net-new GCP services:
+> page is **path-based** on the apex (`built-in-saudi.com/book/<code>`) — the
+> `book-a-meeting` subdomain (and Cloudflare) is deferred; **full Google Calendar
+> sync** (free/busy + auto-create events), **Resend** for email + `.ics`, plus Web
+> Push + Telegram DM on booking. Net-new GCP services:
 > **zero** — it rides the prayer-alerts stack (Cloud Functions gen2 + Firestore +
 > VAPID). The notes below are the original scoping rationale.
 

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -76,6 +76,15 @@ the box only for what the browser genuinely can't.
 
 ## The booking service ("book a meeting with me")
 
+> **Now being built** — this graduated from brainstorm to a real tool. Full
+> architecture, data model, endpoints and the external-setup checklist live in
+> [`tools/book-with-me.md`](./tools/book-with-me.md). Decisions locked: booking
+> page on a Cloudflare Pages **subdomain** (`book-a-meeting.built-in-saudi.com/<code>`),
+> **full Google Calendar sync** (free/busy + auto-create events), **Resend** for
+> email + `.ics`, plus Web Push + Telegram DM on booking. Net-new GCP services:
+> **zero** — it rides the prayer-alerts stack (Cloud Functions gen2 + Firestore +
+> VAPID). The notes below are the original scoping rationale.
+
 - **Why it's the best first backend feature:** trivial compute, always-on but
   cheap, no big privacy tension (it's *your* calendar, not user files), and it's
   a real, personal, monetisable service.

--- a/docs/tools/book-with-me.md
+++ b/docs/tools/book-with-me.md
@@ -1,6 +1,7 @@
 # Book With Me (Calendly-style scheduler)
 
-- **Slug:** `/tools/book-with-me` (host dashboard) · **Public booking:** `book-a-meeting.built-in-saudi.com/<code>`
+- **Slug:** `/tools/book-with-me` (host dashboard) · **Public booking:** `built-in-saudi.com/book/<code>`
+  (path-based; the `book-a-meeting` subdomain is deferred, so no Cloudflare)
 - **Category:** Business · **Priority:** Tier 1 (flagship)
 - **Runs:** hybrid — host UI is client-side; booking/notifications need the backend (badge ⚙︎)
 - **Status:** In progress
@@ -24,10 +25,12 @@ our auth + subdomain + transactional-email patterns for everything after it.
    connect, notification setup (Web Push subscribe + Telegram link), and the
    shareable link. Host state persists to Firestore via `saveSchedule`.
 2. **Public booking page** — `src/pages/BookingPage.tsx` at
-   `/:lang/book/:code`, also served at the apex-free subdomain root
-   `book-a-meeting.built-in-saudi.com/<code>`. No login. Shows real open slots =
-   **drawn availability − Google free/busy − existing bookings**; collects booker
-   name + email + note; books.
+   `/:lang/book/:code`, shared as `built-in-saudi.com/book/<code>` (a bare
+   `/book/<code>` redirects to the visitor's locale via Layout, so links aren't
+   language-locked). No login. Shows real open slots = **drawn availability −
+   Google free/busy − existing bookings**; collects booker name + email + note;
+   books. The `book-a-meeting` subdomain is deferred — path-based needs no extra
+   host, so Cloudflare is skipped for now.
 
 ## Architecture — reuses the prayer-alerts backend wholesale
 
@@ -152,10 +155,10 @@ These need accounts/click-ops the code can't do:
    `googleAuthCallback` function URL. Add `calendar.events` + `calendar.freebusy`
    scopes and submit the consent screen for verification. Client ID → repo var,
    client secret → repo secret.
-2. **Cloudflare Pages** — new Pages project from this repo, custom domain
-   `book-a-meeting.built-in-saudi.com`; add the CNAME in Google Cloud DNS
-   (`built-in-saudi` zone). The Pages build serves the same SPA; the subdomain
-   root path maps to the booking route (see `_redirects`).
+2. ~~**Cloudflare Pages**~~ — **deferred.** Booking is path-based
+   (`built-in-saudi.com/book/<code>`) on the existing GitHub Pages host, so no new
+   host/DNS is needed. If we later want the `book-a-meeting` subdomain, stand up a
+   Cloudflare Pages project on this repo with a wildcard CNAME (see CLAUDE.md).
 3. **Resend** — sign up, verify `built-in-saudi.com` as a sending domain (DKIM/SPF
    TXT in Cloud DNS). API key → repo secret `RESEND_API_KEY`.
 4. **Telegram** — create a bot via @BotFather; bot token → repo secret

--- a/docs/tools/book-with-me.md
+++ b/docs/tools/book-with-me.md
@@ -1,0 +1,165 @@
+# Book With Me (Calendly-style scheduler)
+
+- **Slug:** `/tools/book-with-me` (host dashboard) · **Public booking:** `book-a-meeting.built-in-saudi.com/<code>`
+- **Category:** Business · **Priority:** Tier 1 (flagship)
+- **Runs:** hybrid — host UI is client-side; booking/notifications need the backend (badge ⚙︎)
+- **Status:** In progress
+- **Locale wedge:** bilingual booking pages (AR/EN), Asia/Riyadh-first timezone handling
+
+## Why
+
+Calendly's core loop — *set your availability once, share one link, let people
+self-book without the email ping-pong* — is genuinely useful and universally
+buried behind sign-ups and upsells. We give it away: a clean weekly
+availability painter, a shareable link, real Google Calendar conflict-checking,
+and instant push/Telegram/email on every booking. It's our first tool where the
+**host** logs in (bookers never do — they just pick a slot), so it establishes
+our auth + subdomain + transactional-email patterns for everything after it.
+
+## The two apps
+
+1. **Host dashboard** — `src/tools/book-with-me/BookWithMeTool.tsx`, lives in the
+   catalog like any tool. Google Sign-In, the **drag-to-paint weekly availability
+   grid**, meeting config (length / gap / buffer / horizon), Google Calendar
+   connect, notification setup (Web Push subscribe + Telegram link), and the
+   shareable link. Host state persists to Firestore via `saveSchedule`.
+2. **Public booking page** — `src/pages/BookingPage.tsx` at
+   `/:lang/book/:code`, also served at the apex-free subdomain root
+   `book-a-meeting.built-in-saudi.com/<code>`. No login. Shows real open slots =
+   **drawn availability − Google free/busy − existing bookings**; collects booker
+   name + email + note; books.
+
+## Architecture — reuses the prayer-alerts backend wholesale
+
+**Net-new GCP services: zero.** Everything sits on infra we already run:
+
+| Need | Service | Status |
+|---|---|---|
+| Store hosts, availability, bookings | **Firestore** | ✅ provisioned — add `bookingHosts` + `bookings` |
+| API endpoints | **Cloud Functions gen2** (`blitz-ksa`/`us-central1`, nodejs20, ESM) | ✅ WIF deploy pipeline exists |
+| Device alert on booking | **Web Push (VAPID)** | ✅ reuse `src/lib/push.ts` + existing keys |
+| Optional "meeting in 1h" reminders | **Cloud Scheduler** | ✅ exists — deferred, not in v1 |
+
+New endpoints (each an `http('name', …)` in `functions/index.js`, matching the
+existing one-function-per-endpoint + CORS-preamble convention):
+
+- `googleAuthStart` / `googleAuthCallback` — host OAuth (offline, stores refresh token).
+- `saveSchedule` — upsert host availability + meeting config + notify prefs (auth: verified Google ID token).
+- `getAvailability` — public; returns open slots for a `<code>` over the booking horizon.
+- `book` — public; re-validates the slot, writes the booking, creates the Google Calendar event, fires all notifications.
+- `linkTelegram` — associates a Telegram chat id with a host (via bot deep-link `/start <code>`).
+- Push reuses the existing `subscribe`/`unsubscribe`; booking prefs are additive fields on the subscription doc (same merge pattern as prayer/adhkar).
+
+### Data model (Firestore)
+
+`bookingHosts/{uid}` — one per signed-in Google host:
+```
+{
+  code,                    // short public slug → the shareable link (indexed/unique)
+  email, name, picture,    // from Google profile
+  tz,                      // IANA, default 'Asia/Riyadh'
+  meeting: { minutes: 45, gapMinutes: 0, bufferBefore: 0, bufferAfter: 0,
+             horizonDays: 30, minNoticeHours: 4, title, location },
+  availability: [ { day: 0..6, start: '09:00', end: '17:00' }, ... ],  // weekly, host-tz local
+  google: { refreshToken, calendarId: 'primary', connectedAt } | null,
+  notify: { push: bool, telegram: bool, email: bool, telegramChatId },
+  createdAt, updatedAt,
+}
+```
+
+`bookings/{id}`:
+```
+{
+  hostUid, code,
+  startUtc, endUtc,        // Timestamps
+  booker: { name, email, note },
+  gcalEventId | null,
+  status: 'confirmed' | 'cancelled',
+  createdAt,
+}
+```
+
+### Booking flow (one `book()` invocation)
+
+1. Validate the slot is still inside availability, not in the past, respects
+   `minNoticeHours`, and doesn't collide with an existing `bookings` doc.
+2. Re-check Google **free/busy** for the host (guards against events booked
+   elsewhere since the page loaded).
+3. Write the `bookings` doc (transaction, so two people can't grab the same slot).
+4. Create the **Google Calendar event** on the host's calendar with the booker as
+   an attendee (Google sends its own invite too).
+5. Fire notifications: **Web Push** + **Telegram sendMessage** to the host, and a
+   **Resend** confirmation email to the booker (and host) with a generated `.ics`.
+
+## Notifications — cost
+
+- **Device push** — free, reuses VAPID. Host subscribes from the dashboard.
+- **Telegram DM** — **free** via Bot API. One BotFather bot; host links their chat
+  with the deep-link `t.me/<bot>?start=<code>`; `book()` calls `sendMessage`.
+- **Email — needed**, for the booker confirmation + a real calendar entry.
+  Cheapest reliable path is **Resend** (free tier 100/day, 3k/mo — ample for a
+  personal booking tool), sending an HTML confirmation with a server-generated
+  **`.ics`** attachment so both parties get a calendar event even without the
+  Google integration. SES is cheaper at scale but needs more setup and isn't free
+  off-EC2 — not worth it at this volume.
+
+## Google Calendar OAuth — verification note
+
+Reading free/busy + creating events needs the `calendar.events` +
+`calendar.freebusy` scopes, which are **sensitive** and put the OAuth consent
+screen into Google's verification review (one-time, a few days). So the tool is
+built in two layers that ship independently:
+
+- **Layer 1 (no verification):** host paints availability; conflicts are computed
+  against our own `bookings` only. Fully functional the day we deploy.
+- **Layer 2 (after verification clears):** connect Google → real free/busy +
+  auto-created events. Additive; the host just gains a "Connect Google Calendar"
+  button. We are never blocked waiting on Google.
+
+## Requirements (v1)
+
+- [ ] Host: Google Sign-In (GIS one-tap / button; verify ID token server-side).
+- [ ] Host: drag-to-paint weekly availability grid (7 day-columns × time rows),
+      paint + erase, keyboard/pointer, `prefers-reduced-motion` safe.
+- [ ] Host: meeting config — length (45 default), gap, buffer, horizon, min-notice.
+- [ ] Host: shareable link + copy; QR of the link (reuse qr logic later).
+- [ ] Host: notification setup — push subscribe, Telegram link, email toggle.
+- [ ] Booking page: fetch availability by `<code>`, render open slots grouped by
+      day in the booker's timezone, pick → enter name/email/note → confirm.
+- [ ] `book()` transaction prevents double-booking; sends push + Telegram + email.
+- [ ] Layer 2: Google connect → free/busy filtering + event creation.
+
+## Acceptance criteria
+
+- Painting Mon 09:00–12:00 with 45-min meetings + 0 gap yields slots 09:00,
+  09:45, 10:45(+buffer)… correctly, in the booker's tz.
+- Two simultaneous `book()` calls for the same slot: exactly one succeeds.
+- On booking, host gets a push + Telegram DM; booker gets an email with a
+  working `.ics`.
+
+## Out of scope (v1)
+
+- Multiple meeting types per host, team/round-robin, payments, reschedule/cancel
+  self-service links (park in a follow-up), SMS, recurring meetings.
+
+## External setup checklist (owner actions)
+
+These need accounts/click-ops the code can't do:
+
+1. **Google OAuth** — in `blitz-ksa` create an OAuth 2.0 Client ID (Web).
+   Authorized origins: `https://built-in-saudi.com`,
+   `https://book-a-meeting.built-in-saudi.com`. Redirect URI: the
+   `googleAuthCallback` function URL. Add `calendar.events` + `calendar.freebusy`
+   scopes and submit the consent screen for verification. Client ID → repo var,
+   client secret → repo secret.
+2. **Cloudflare Pages** — new Pages project from this repo, custom domain
+   `book-a-meeting.built-in-saudi.com`; add the CNAME in Google Cloud DNS
+   (`built-in-saudi` zone). The Pages build serves the same SPA; the subdomain
+   root path maps to the booking route (see `_redirects`).
+3. **Resend** — sign up, verify `built-in-saudi.com` as a sending domain (DKIM/SPF
+   TXT in Cloud DNS). API key → repo secret `RESEND_API_KEY`.
+4. **Telegram** — create a bot via @BotFather; bot token → repo secret
+   `TELEGRAM_BOT_TOKEN`; bot username → client config.
+5. **GCP secrets** on the functions deploy (same mechanism as `VAPID_*`):
+   `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `RESEND_API_KEY`,
+   `TELEGRAM_BOT_TOKEN`. Reuse existing `VAPID_*` + `SENDER_SECRET`.

--- a/functions/README.md
+++ b/functions/README.md
@@ -10,6 +10,39 @@ project `blitz-ksa`, region `us-central1`, plus Firestore + Cloud Scheduler.
   it every minute with `?secret=…`; it pushes any subscription whose `nextNotifyAt`
   has passed, then recomputes the next one. 404/410 responses prune dead subs.
 
+## Book With Me (booking backend — `booking.js`)
+
+Calendly-style scheduling. Registered from `booking.js` (imported by `index.js`).
+No new npm deps — Google/Resend/Telegram are reached over `fetch`, host sessions
+are HMAC-signed with `node:crypto`, the `.ics` is hand-written. See
+[`../docs/tools/book-with-me.md`](../docs/tools/book-with-me.md).
+
+- **booking-google-start** (`bookingGoogleStart`) — `GET ?code&locale` → 302 to
+  Google consent (offline, calendar scopes).
+- **booking-google-callback** (`bookingGoogleCallback`) — exchanges the code,
+  upserts `bookingHosts/{googleSub}` with the refresh token, redirects back to the
+  dashboard with an HMAC `#hsid` session. **The deployed name must stay
+  `booking-google-callback` — it's the OAuth redirect URI in `booking.js`.**
+- **save-schedule** (`saveSchedule`) — `POST { hsid, code, tz, meeting, availability, notify, pushSub? }` → upserts the host (hsid-authenticated).
+- **get-availability** (`getAvailability`) — `POST { code }` → host meta + open slot epochs (drawn availability − bookings − Google free/busy).
+- **book** — `POST { code, startUtc, name, email, note }` → transactional booking (deterministic id `hostUid_startMs` prevents double-booking), creates the Calendar event, fires push + Telegram + Resend email w/ `.ics`.
+- **telegram-webhook** (`telegramWebhook`) — Telegram calls it; `/start <code>` links the sender's chat to that host.
+
+### Extra secrets/vars for booking
+
+- `GOOGLE_OAUTH_CLIENT_ID` (repo **variable** — public) / `GOOGLE_OAUTH_CLIENT_SECRET` (secret).
+- `RESEND_API_KEY` (secret) — Resend transactional email; sending domain `built-in-saudi.com` must be verified.
+- `TELEGRAM_BOT_TOKEN` (secret) — from @BotFather. `SENDER_SECRET` is reused to sign host sessions.
+
+### One-time Telegram webhook
+
+After deploy, point the bot at the webhook once:
+
+```sh
+HOOK=$(gcloud functions describe telegram-webhook --gen2 --region=us-central1 --format='value(serviceConfig.uri)')
+curl "https://api.telegram.org/bot<token>/setWebhook?url=${HOOK}"
+```
+
 ## Important: ESM only
 
 `adhan`'s CommonJS build is broken (`Cannot find module './CalculationMethod.js'`),

--- a/functions/booking.js
+++ b/functions/booking.js
@@ -47,9 +47,8 @@ const OAUTH_SCOPES = [
 
 function cors(req, res) {
   const origin = (req.headers && req.headers.origin) || ''
-  // Allow the apex, any *.built-in-saudi.com subdomain (incl. the booking
-  // subdomain), and Cloudflare Pages preview builds during setup.
-  const ok = /^https:\/\/([a-z0-9-]+\.)?built-in-saudi\.com$/.test(origin) || /\.pages\.dev$/.test(origin)
+  // Allow the apex and any *.built-in-saudi.com subdomain.
+  const ok = /^https:\/\/([a-z0-9-]+\.)?built-in-saudi\.com$/.test(origin)
   res.set('Access-Control-Allow-Origin', ok ? origin : SITE)
   res.set('Vary', 'Origin')
   res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')

--- a/functions/booking.js
+++ b/functions/booking.js
@@ -1,0 +1,575 @@
+// Book With Me — the Calendly-style booking backend.
+//
+// Design notes (see docs/tools/book-with-me.md):
+//  • No new npm deps: Google, Resend and Telegram are all reached over Node 20's
+//    global fetch; host sessions are HMAC-signed with node:crypto; the .ics is
+//    hand-written. Leanness is on-brand.
+//  • One OAuth authorization-code flow does double duty: it signs the host in
+//    (we read the id_token straight from Google's token endpoint, so it's
+//    trusted) and grabs an offline refresh token for calendar access.
+//  • The client never sees the refresh token. After the callback we mint our own
+//    short-lived "hsid" session (HMAC over {sub,email,name}) and hand it back in
+//    the redirect fragment; saveSchedule/subscribeHostPush verify it.
+//  • Firestore: bookingHosts/{googleSub}, bookings/{uid_startMs} (the
+//    deterministic booking id makes double-booking a transaction, not a query).
+
+import { http } from '@google-cloud/functions-framework'
+import firestore from '@google-cloud/firestore'
+import webpush from 'web-push'
+import crypto from 'node:crypto'
+
+const { Firestore } = firestore
+const db = new Firestore()
+const HOSTS = 'bookingHosts'
+const BOOKINGS = 'bookings'
+
+const SITE = 'https://built-in-saudi.com'
+const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID || ''
+const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET || ''
+const RESEND_API_KEY = process.env.RESEND_API_KEY || ''
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || ''
+const SESSION_SECRET = process.env.SENDER_SECRET || 'x' // reuse the existing shared secret for HMAC
+
+// This function's own base URL, used as the OAuth redirect target. All gen2
+// functions in this project share the us-central1-<project> host.
+const FN_BASE = 'https://us-central1-blitz-ksa.cloudfunctions.net'
+const REDIRECT_URI = `${FN_BASE}/booking-google-callback`
+
+const OAUTH_SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/calendar.freebusy',
+].join(' ')
+
+// ---- CORS (browser-facing endpoints) ---------------------------------------
+
+function cors(req, res) {
+  const origin = (req.headers && req.headers.origin) || ''
+  // Allow the apex, any *.built-in-saudi.com subdomain (incl. the booking
+  // subdomain), and Cloudflare Pages preview builds during setup.
+  const ok = /^https:\/\/([a-z0-9-]+\.)?built-in-saudi\.com$/.test(origin) || /\.pages\.dev$/.test(origin)
+  res.set('Access-Control-Allow-Origin', ok ? origin : SITE)
+  res.set('Vary', 'Origin')
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.set('Access-Control-Allow-Headers', 'Content-Type')
+}
+
+// ---- host session token (our own, HMAC) ------------------------------------
+
+const b64u = (buf) => Buffer.from(buf).toString('base64url')
+const SESSION_TTL_MS = 30 * 86400000
+
+function signSession(payload) {
+  const body = b64u(JSON.stringify({ ...payload, exp: Date.now() + SESSION_TTL_MS }))
+  const sig = crypto.createHmac('sha256', SESSION_SECRET).update(body).digest('base64url')
+  return `${body}.${sig}`
+}
+
+function verifySession(token) {
+  if (!token || typeof token !== 'string' || !token.includes('.')) return null
+  const [body, sig] = token.split('.')
+  const expect = crypto.createHmac('sha256', SESSION_SECRET).update(body).digest('base64url')
+  // constant-time compare
+  if (sig.length !== expect.length || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expect))) return null
+  try {
+    const data = JSON.parse(Buffer.from(body, 'base64url').toString())
+    if (!data.exp || Date.now() > data.exp) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+// ---- Google REST helpers ----------------------------------------------------
+
+function decodeJwtPayload(jwt) {
+  // The id_token comes straight from Google's token endpoint over TLS, so we can
+  // trust its payload without re-verifying the signature.
+  try {
+    return JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString())
+  } catch {
+    return {}
+  }
+}
+
+async function exchangeCode(code) {
+  const r = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      redirect_uri: REDIRECT_URI,
+      grant_type: 'authorization_code',
+    }),
+  })
+  if (!r.ok) throw new Error(`token exchange ${r.status}: ${(await r.text()).slice(0, 200)}`)
+  return r.json() // { access_token, refresh_token?, id_token, expires_in }
+}
+
+async function accessTokenFor(refreshToken) {
+  const r = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  })
+  if (!r.ok) throw new Error(`refresh ${r.status}`)
+  return (await r.json()).access_token
+}
+
+async function googleBusy(accessToken, calId, timeMinIso, timeMaxIso) {
+  const r = await fetch('https://www.googleapis.com/calendar/v3/freeBusy', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timeMin: timeMinIso, timeMax: timeMaxIso, items: [{ id: calId }] }),
+  })
+  if (!r.ok) throw new Error(`freeBusy ${r.status}`)
+  const data = await r.json()
+  const cal = (data.calendars && data.calendars[calId]) || {}
+  return (cal.busy || []).map((b) => ({ start: Date.parse(b.start), end: Date.parse(b.end) }))
+}
+
+async function insertEvent(accessToken, calId, event) {
+  const r = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calId)}/events?sendUpdates=all`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+    },
+  )
+  if (!r.ok) throw new Error(`insertEvent ${r.status}: ${(await r.text()).slice(0, 200)}`)
+  return r.json()
+}
+
+// ---- notifications ----------------------------------------------------------
+
+async function sendTelegram(chatId, text) {
+  if (!TELEGRAM_BOT_TOKEN || !chatId) return
+  await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'HTML', disable_web_page_preview: true }),
+  }).catch(() => {})
+}
+
+async function sendEmail({ to, subject, html, ics }) {
+  if (!RESEND_API_KEY || !to) return
+  const body = {
+    from: 'Built in Saudi <book@built-in-saudi.com>',
+    to: [to],
+    subject,
+    html,
+  }
+  if (ics) {
+    body.attachments = [{ filename: 'invite.ics', content: Buffer.from(ics).toString('base64') }]
+  }
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${RESEND_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }).catch(() => {})
+}
+
+function icsStamp(ms) {
+  return new Date(ms).toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+}
+
+function buildICS({ uid, start, end, summary, description, location, organizerEmail, attendeeEmail }) {
+  const esc = (s) => String(s || '').replace(/([,;\\])/g, '\\$1').replace(/\n/g, '\\n')
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Built in Saudi//Book With Me//EN',
+    'METHOD:REQUEST',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${icsStamp(Date.now())}`,
+    `DTSTART:${icsStamp(start)}`,
+    `DTEND:${icsStamp(end)}`,
+    `SUMMARY:${esc(summary)}`,
+    description ? `DESCRIPTION:${esc(description)}` : '',
+    location ? `LOCATION:${esc(location)}` : '',
+    organizerEmail ? `ORGANIZER:mailto:${organizerEmail}` : '',
+    attendeeEmail ? `ATTENDEE;RSVP=TRUE:mailto:${attendeeEmail}` : '',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ]
+    .filter(Boolean)
+    .join('\r\n')
+}
+
+// ---- timezone + slot math ---------------------------------------------------
+
+/** Offset (ms) of `tz` at the given UTC instant. */
+function tzOffsetMs(tz, utcMs) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz, hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+  const p = {}
+  for (const part of dtf.formatToParts(new Date(utcMs))) p[part.type] = part.value
+  const asUtc = Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour === 24 ? 0 : +p.hour, +p.minute, +p.second)
+  return asUtc - utcMs
+}
+
+/** Wall-clock time in `tz` → UTC epoch ms. */
+function zonedToUtc(y, m, d, hh, mm, tz) {
+  const guess = Date.UTC(y, m, d, hh, mm)
+  return guess - tzOffsetMs(tz, guess)
+}
+
+/** {year,month,day,weekday} of a UTC instant, as seen in `tz`. */
+function partsInTz(utcMs, tz) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz, weekday: 'short', year: 'numeric', month: '2-digit', day: '2-digit',
+  })
+  const p = {}
+  for (const part of dtf.formatToParts(new Date(utcMs))) p[part.type] = part.value
+  const wd = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }[p.weekday]
+  return { y: +p.year, m: +p.month, d: +p.day, weekday: wd }
+}
+
+const hhmmToMin = (s) => {
+  const [h, m] = s.split(':').map(Number)
+  return h * 60 + m
+}
+
+/**
+ * Open slot start epochs over the horizon = drawn availability, stepped by
+ * (length + gap), minus min-notice, minus busy ranges.
+ */
+function openSlots(host, busy, now) {
+  const tz = host.tz || 'Asia/Riyadh'
+  const meeting = host.meeting || {}
+  const windows = host.availability || []
+  const lenMs = (meeting.minutes || 45) * 60000
+  const stepMs = ((meeting.minutes || 45) + (meeting.gapMinutes || 0)) * 60000
+  const earliest = now + (meeting.minNoticeHours || 0) * 3600000
+  const horizonEnd = now + (meeting.horizonDays || 30) * 86400000
+  const slots = []
+  // Iterate calendar days in host tz from today until the horizon.
+  for (let dayOffset = 0; dayOffset <= (meeting.horizonDays || 30) + 1; dayOffset++) {
+    const probe = now + dayOffset * 86400000
+    const { y, m, d, weekday } = partsInTz(probe, tz)
+    for (const w of windows) {
+      if (w.day !== weekday) continue
+      const winStart = zonedToUtc(y, m - 1, d, 0, 0, tz) + hhmmToMin(w.start) * 60000
+      const winEnd = zonedToUtc(y, m - 1, d, 0, 0, tz) + hhmmToMin(w.end) * 60000
+      for (let s = winStart; s + lenMs <= winEnd + 1; s += stepMs) {
+        if (s < earliest || s > horizonEnd) continue
+        const e = s + lenMs
+        if (busy.some((b) => s < b.end && e > b.start)) continue
+        slots.push(s)
+      }
+    }
+  }
+  return [...new Set(slots)].sort((a, b) => a - b)
+}
+
+async function hostByCode(code) {
+  if (!code) return null
+  const snap = await db.collection(HOSTS).where('code', '==', String(code)).limit(1).get()
+  return snap.empty ? null : { id: snap.docs[0].id, ...snap.docs[0].data() }
+}
+
+// ============================================================================
+// Endpoints
+// ============================================================================
+
+// GET ?code=<localCode>&locale=en → 302 to Google's consent screen.
+http('bookingGoogleStart', async (req, res) => {
+  try {
+    const code = String(req.query.code || '')
+    const locale = req.query.locale === 'ar' ? 'ar' : 'en'
+    const state = b64u(JSON.stringify({ code, locale, n: crypto.randomBytes(8).toString('hex') }))
+    const url = `https://accounts.google.com/o/oauth2/v2/auth?${new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      response_type: 'code',
+      scope: OAUTH_SCOPES,
+      access_type: 'offline',
+      prompt: 'consent',
+      include_granted_scopes: 'true',
+      state,
+    })}`
+    res.redirect(302, url)
+  } catch (e) {
+    res.status(500).send(String((e && e.message) || e))
+  }
+})
+
+// GET ?code=…&state=… → exchange, upsert host, redirect back with #hsid.
+http('bookingGoogleCallback', async (req, res) => {
+  try {
+    const code = req.query.code
+    if (!code) return res.status(400).send('missing code')
+    let st = {}
+    try { st = JSON.parse(Buffer.from(String(req.query.state || ''), 'base64url').toString()) } catch { /* ignore */ }
+    const tokens = await exchangeCode(code)
+    const id = decodeJwtPayload(tokens.id_token || '')
+    const sub = id.sub
+    if (!sub) return res.status(400).send('no subject in id_token')
+
+    const ref = db.collection(HOSTS).doc(sub)
+    const existing = (await ref.get()).data() || {}
+    // Keep the previously-stored refresh token if Google didn't send a new one
+    // (it only returns it on the first consent).
+    const refreshToken = tokens.refresh_token || (existing.google && existing.google.refreshToken) || null
+    // Assign a code: keep existing, else the local code from state (if free), else a fresh one.
+    let hostCode = existing.code || st.code || crypto.randomBytes(4).toString('hex')
+    if (!existing.code && st.code) {
+      const clash = await hostByCode(st.code)
+      if (clash && clash.id !== sub) hostCode = crypto.randomBytes(4).toString('hex')
+    }
+    await ref.set(
+      {
+        code: hostCode,
+        email: id.email || existing.email || null,
+        name: id.name || existing.name || null,
+        picture: id.picture || existing.picture || null,
+        google: { refreshToken, calendarId: (existing.google && existing.google.calendarId) || 'primary', connectedAt: new Date() },
+        updatedAt: new Date(),
+      },
+      { merge: true },
+    )
+    const hsid = signSession({ sub, email: id.email, name: id.name })
+    const locale = st.locale === 'ar' ? 'ar' : 'en'
+    res.redirect(302, `${SITE}/${locale}/tools/book-with-me#hsid=${hsid}&code=${hostCode}`)
+  } catch (e) {
+    res.status(500).send(String((e && e.message) || e))
+  }
+})
+
+// POST { hsid, code, tz, meeting, availability, notify, pushSub? } → upsert host.
+http('saveSchedule', async (req, res) => {
+  cors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).send('')
+  if (req.method !== 'POST') return res.status(405).send('POST only')
+  try {
+    const { hsid, code, tz, meeting, availability, notify, pushSub } = req.body || {}
+    const sess = verifySession(hsid)
+    if (!sess) return res.status(401).json({ error: 'invalid session' })
+
+    // Enforce code uniqueness across hosts.
+    if (code) {
+      const clash = await hostByCode(code)
+      if (clash && clash.id !== sess.sub) return res.status(409).json({ error: 'code taken' })
+    }
+    const patch = { updatedAt: new Date() }
+    if (code) patch.code = String(code)
+    if (tz) patch.tz = String(tz)
+    if (meeting) patch.meeting = meeting
+    if (Array.isArray(availability)) patch.availability = availability
+    if (notify) patch.notify = notify
+    if (pushSub && pushSub.endpoint) patch.pushSub = pushSub
+    await db.collection(HOSTS).doc(sess.sub).set(patch, { merge: true })
+    res.json({ ok: true })
+  } catch (e) {
+    res.status(500).json({ error: String((e && e.message) || e) })
+  }
+})
+
+// POST { code } → host meta + open slot start epochs (UTC ms) over the horizon.
+http('getAvailability', async (req, res) => {
+  cors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).send('')
+  if (req.method !== 'POST') return res.status(405).send('POST only')
+  try {
+    const host = await hostByCode(req.body && req.body.code)
+    if (!host) return res.status(404).json({ error: 'not found' })
+    const now = Date.now()
+    const horizonEnd = now + ((host.meeting && host.meeting.horizonDays) || 30) * 86400000
+
+    // Busy = existing confirmed bookings + (if connected) Google free/busy.
+    const busy = []
+    const bk = await db
+      .collection(BOOKINGS)
+      .where('hostUid', '==', host.id)
+      .where('startUtc', '>=', new Date(now))
+      .get()
+    for (const d of bk.docs) {
+      const b = d.data()
+      if (b.status === 'cancelled') continue
+      busy.push({ start: b.startUtc.toMillis(), end: b.endUtc.toMillis() })
+    }
+    if (host.google && host.google.refreshToken) {
+      try {
+        const at = await accessTokenFor(host.google.refreshToken)
+        const gbusy = await googleBusy(at, host.google.calendarId || 'primary', new Date(now).toISOString(), new Date(horizonEnd).toISOString())
+        busy.push(...gbusy)
+      } catch (e) {
+        console.error('freebusy failed:', String((e && e.message) || e))
+      }
+    }
+    const slots = openSlots(host, busy, now)
+    res.json({
+      ok: true,
+      host: {
+        name: host.name || null,
+        tz: host.tz || 'Asia/Riyadh',
+        minutes: (host.meeting && host.meeting.minutes) || 45,
+        title: (host.meeting && host.meeting.title) || 'Meeting',
+        location: (host.meeting && host.meeting.location) || '',
+      },
+      slots,
+    })
+  } catch (e) {
+    res.status(500).json({ error: String((e && e.message) || e) })
+  }
+})
+
+// POST { code, startUtc, name, email, note } → book (transactional), notify.
+http('book', async (req, res) => {
+  cors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).send('')
+  if (req.method !== 'POST') return res.status(405).send('POST only')
+  try {
+    const { code, startUtc, name, email, note } = req.body || {}
+    if (!startUtc || !name || !email) return res.status(400).json({ error: 'missing fields' })
+    const host = await hostByCode(code)
+    if (!host) return res.status(404).json({ error: 'not found' })
+
+    const start = Number(startUtc)
+    const lenMs = ((host.meeting && host.meeting.minutes) || 45) * 60000
+    const end = start + lenMs
+    if (start < Date.now()) return res.status(400).json({ error: 'in the past' })
+
+    // Validate the slot is genuinely open right now (availability + freebusy).
+    let busy = []
+    if (host.google && host.google.refreshToken) {
+      try {
+        const at = await accessTokenFor(host.google.refreshToken)
+        busy = await googleBusy(at, host.google.calendarId || 'primary', new Date(start).toISOString(), new Date(end).toISOString())
+      } catch { /* if freebusy fails, fall back to availability + booking lock */ }
+    }
+    const stillOpen = openSlots(host, busy, Date.now() - 60000).includes(start)
+    if (!stillOpen) return res.status(409).json({ error: 'slot no longer available' })
+
+    // Atomic double-booking guard via a deterministic doc id per slot.
+    const bId = `${host.id}_${start}`
+    const bRef = db.collection(BOOKINGS).doc(bId)
+    await db.runTransaction(async (t) => {
+      const snap = await t.get(bRef)
+      if (snap.exists && snap.data().status !== 'cancelled') throw new Error('ALREADY_BOOKED')
+      t.set(bRef, {
+        hostUid: host.id,
+        code: host.code,
+        startUtc: new Date(start),
+        endUtc: new Date(end),
+        booker: { name: String(name).slice(0, 120), email: String(email).slice(0, 160), note: String(note || '').slice(0, 500) },
+        status: 'confirmed',
+        gcalEventId: null,
+        createdAt: new Date(),
+      })
+    }).catch((e) => {
+      if (String(e.message).includes('ALREADY_BOOKED')) {
+        const err = new Error('slot no longer available'); err.code = 409; throw err
+      }
+      throw e
+    })
+
+    const title = (host.meeting && host.meeting.title) || 'Meeting'
+    const location = (host.meeting && host.meeting.location) || ''
+    const summary = `${title} — ${name}`
+
+    // Create the Google Calendar event (best-effort; booking already persisted).
+    if (host.google && host.google.refreshToken) {
+      try {
+        const at = await accessTokenFor(host.google.refreshToken)
+        const ev = await insertEvent(at, host.google.calendarId || 'primary', {
+          summary,
+          description: note ? `Booked via Built in Saudi.\n\n${note}` : 'Booked via Built in Saudi.',
+          location,
+          start: { dateTime: new Date(start).toISOString() },
+          end: { dateTime: new Date(end).toISOString() },
+          attendees: [{ email: String(email), displayName: String(name) }],
+        })
+        if (ev && ev.id) await bRef.update({ gcalEventId: ev.id })
+      } catch (e) {
+        console.error('gcal insert failed:', String((e && e.message) || e))
+      }
+    }
+
+    // Notify the host: push + Telegram.
+    const whenHost = new Date(start).toLocaleString('en-GB', { timeZone: host.tz || 'Asia/Riyadh' })
+    const notify = host.notify || {}
+    if (notify.push !== false && host.pushSub && host.pushSub.endpoint) {
+      try {
+        await webpush.sendNotification(host.pushSub, JSON.stringify({
+          title: `New booking: ${name}`,
+          body: `${title} · ${whenHost}`,
+          tag: 'booking',
+          url: `${SITE}/en/tools/book-with-me`,
+        }))
+      } catch (e) { /* prune handled elsewhere */ }
+    }
+    if (notify.telegram !== false && host.telegramChatId) {
+      await sendTelegram(
+        host.telegramChatId,
+        `📅 <b>New booking</b>\n${name} (${email})\n${title} · ${whenHost}${note ? `\n\n${note}` : ''}`,
+      )
+    }
+
+    // Email the booker (and host) a confirmation with a real .ics.
+    const ics = buildICS({
+      uid: `${bId}@built-in-saudi.com`,
+      start, end, summary: title, description: note || '', location,
+      organizerEmail: host.email, attendeeEmail: String(email),
+    })
+    const whenBooker = new Date(start).toISOString()
+    if (notify.email !== false) {
+      await sendEmail({
+        to: String(email),
+        subject: `Confirmed: ${title}`,
+        html: `<p>Your ${title.toLowerCase()} is booked.</p><p><b>When:</b> ${whenBooker} (UTC)</p>${location ? `<p><b>Where:</b> ${location}</p>` : ''}<p>Added to your calendar via the attached invite.</p>`,
+        ics,
+      })
+      if (host.email) {
+        await sendEmail({
+          to: host.email,
+          subject: `New booking: ${name}`,
+          html: `<p><b>${name}</b> (${email}) booked ${title}.</p><p><b>When:</b> ${whenHost}</p>${note ? `<p><b>Note:</b> ${note}</p>` : ''}`,
+          ics,
+        })
+      }
+    }
+
+    res.json({ ok: true })
+  } catch (e) {
+    if (e && e.code === 409) return res.status(409).json({ error: e.message })
+    res.status(500).json({ error: String((e && e.message) || e) })
+  }
+})
+
+// Telegram webhook: on "/start <code>" link the sender's chat to that host.
+// Set up once with: setWebhook → this function's URL (see functions/README.md).
+http('telegramWebhook', async (req, res) => {
+  try {
+    const msg = req.body && (req.body.message || req.body.edited_message)
+    const text = (msg && msg.text) || ''
+    const chatId = msg && msg.chat && msg.chat.id
+    const m = text.match(/^\/start\s+(\S+)/)
+    if (m && chatId) {
+      const host = await hostByCode(m[1])
+      if (host) {
+        await db.collection(HOSTS).doc(host.id).set({ telegramChatId: chatId }, { merge: true })
+        await sendTelegram(chatId, '✅ Linked. You’ll get a message here whenever someone books with you.')
+      } else {
+        await sendTelegram(chatId, '❌ Couldn’t find that booking link.')
+      }
+    }
+    res.json({ ok: true })
+  } catch (e) {
+    res.status(200).json({ ok: false }) // always 200 so Telegram doesn't retry-storm
+  }
+})

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,10 @@ import { http } from '@google-cloud/functions-framework'
 import firestore from '@google-cloud/firestore'
 import webpush from 'web-push'
 import * as adhan from 'adhan'
+// Book With Me endpoints (bookingGoogleStart/Callback, saveSchedule,
+// getAvailability, book, telegramWebhook). Importing here registers their
+// http() handlers; VAPID is configured below and shared.
+import './booking.js'
 
 const { Firestore } = firestore
 const db = new Firestore()

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -180,6 +180,16 @@ export function CalendarIcon({ className }: P) {
   )
 }
 
+export function CalendarCheckIcon({ className }: P) {
+  return (
+    <svg {...base} className={className} aria-hidden="true">
+      <rect x="3" y="4.5" width="18" height="16" rx="2" />
+      <path d="M3 9h18M8 3v3M16 3v3" />
+      <path d="M8.5 14.5l2.5 2.5 4.5-4.5" />
+    </svg>
+  )
+}
+
 export function GridIcon({ className }: P) {
   return (
     <svg {...base} className={className} aria-hidden="true">

--- a/src/i18n/seo.ts
+++ b/src/i18n/seo.ts
@@ -25,6 +25,11 @@ export interface ToolSeo {
 /** Live (routable) tools only — used to prerender /<locale>/tools/<id>/. */
 export const liveToolSeo: ToolSeo[] = [
   {
+    id: 'book-with-me',
+    en: { name: 'Book With Me', description: 'A free, no-sign-up scheduling link — paint your weekly availability, set the meeting length with gaps and buffers, and share one link. People self-book an open slot without the email back-and-forth; you get a push, a Telegram DM and an email when they book.' },
+    ar: { name: 'احجز معي', description: 'رابط جدولة مجاني بلا تسجيل — ارسم أوقات فراغك الأسبوعية، وحدِّد مدة الاجتماع بفواصل ومهل، وشارك رابطًا واحدًا. يحجز الناس وقتًا متاحًا دون تبادل رسائل، وتصلك إشعارات ورسالة تيليجرام وبريد عند الحجز.' },
+  },
+  {
     id: 'color-tools',
     en: { name: 'Color Picker & Palettes', description: 'Pick a colour and read it as HEX/RGB/HSL, then generate complementary, analogous and triadic palettes plus a shades ramp — copy any swatch. In your browser.' },
     ar: { name: 'منتقي الألوان واللوحات', description: 'اختر لونًا واقرأه بصيغ HEX/RGB/HSL، ثم ولّد لوحات مكمّلة ومتجانسة وثلاثية وتدرّجات — وانسخ أي لون. داخل متصفحك.' },

--- a/src/lib/bookingApi.ts
+++ b/src/lib/bookingApi.ts
@@ -1,0 +1,60 @@
+// Client calls to the Book With Me Cloud Functions. Same host as push.ts.
+const FN = 'https://us-central1-blitz-ksa.cloudfunctions.net'
+
+export interface HostMeta {
+  name: string | null
+  tz: string
+  minutes: number
+  title: string
+  location: string
+}
+
+export interface AvailabilityResponse {
+  ok: true
+  host: HostMeta
+  slots: number[] // open start times, epoch ms (UTC)
+}
+
+export async function getAvailability(code: string): Promise<AvailabilityResponse> {
+  const r = await fetch(`${FN}/get-availability`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })
+  if (r.status === 404) throw new Error('not-found')
+  if (!r.ok) throw new Error('failed')
+  return r.json()
+}
+
+export async function book(input: {
+  code: string
+  startUtc: number
+  name: string
+  email: string
+  note?: string
+}): Promise<{ ok: boolean; conflict?: boolean }> {
+  const r = await fetch(`${FN}/book`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (r.status === 409) return { ok: false, conflict: true }
+  if (!r.ok) throw new Error('failed')
+  return { ok: true }
+}
+
+/** Persist the host's schedule (requires the hsid session from OAuth callback). */
+export async function saveSchedule(input: Record<string, unknown>): Promise<{ ok: boolean }> {
+  const r = await fetch(`${FN}/save-schedule`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!r.ok) throw new Error(String(r.status))
+  return r.json()
+}
+
+/** Full-page redirect to Google to sign in + connect Calendar. */
+export function connectGoogleUrl(code: string, locale: string): string {
+  return `${FN}/booking-google-start?code=${encodeURIComponent(code)}&locale=${locale}`
+}

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useLocale } from '../i18n'
+import { useDocumentMeta } from '../lib/useDocumentMeta'
+import { Button, Input, Textarea, Field, Stack, Panel, Pill } from '../components/ui'
+import { getAvailability, book, type HostMeta } from '../lib/bookingApi'
+
+const STR = {
+  en: {
+    loading: 'Loading availability…',
+    notFound: 'This booking link doesn’t exist.',
+    error: 'Couldn’t load availability. Please try again.',
+    withMe: (n: string) => `Book a meeting with ${n}`,
+    withHost: 'Book a meeting',
+    mins: 'min',
+    yourTz: (tz: string) => `Times shown in your timezone (${tz})`,
+    none: 'No open times in the coming weeks. Check back soon.',
+    pick: 'Pick a time',
+    name: 'Your name',
+    email: 'Your email',
+    note: 'Anything to share? (optional)',
+    confirm: 'Confirm booking',
+    back: 'Back',
+    booking: 'Booking…',
+    booked: 'You’re booked! 🎉',
+    bookedBody: 'A confirmation with a calendar invite is on its way to your email.',
+    gone: 'That slot was just taken. Please pick another.',
+    at: 'at',
+  },
+  ar: {
+    loading: 'جارٍ تحميل الأوقات…',
+    notFound: 'رابط الحجز هذا غير موجود.',
+    error: 'تعذّر تحميل الأوقات. حاول مرة أخرى.',
+    withMe: (n: string) => `احجز اجتماعًا مع ${n}`,
+    withHost: 'احجز اجتماعًا',
+    mins: 'دقيقة',
+    yourTz: (tz: string) => `الأوقات معروضة بتوقيتك (${tz})`,
+    none: 'لا أوقات متاحة في الأسابيع القادمة. عُد قريبًا.',
+    pick: 'اختر وقتًا',
+    name: 'اسمك',
+    email: 'بريدك الإلكتروني',
+    note: 'شيء تودّ مشاركته؟ (اختياري)',
+    confirm: 'تأكيد الحجز',
+    back: 'رجوع',
+    booking: 'جارٍ الحجز…',
+    booked: 'تم حجزك! 🎉',
+    bookedBody: 'رسالة تأكيد مع دعوة تقويم في طريقها إلى بريدك.',
+    gone: 'حُجز هذا الوقت للتو. اختر وقتًا آخر.',
+    at: 'الساعة',
+  },
+}
+
+type Status = 'loading' | 'ready' | 'not-found' | 'error'
+
+export function BookingPage() {
+  const { code } = useParams()
+  const { locale } = useLocale()
+  const s = STR[locale]
+  useDocumentMeta(locale, `/book/${code}`)
+
+  const [status, setStatus] = useState<Status>('loading')
+  const [host, setHost] = useState<HostMeta | null>(null)
+  const [slots, setSlots] = useState<number[]>([])
+  const [selected, setSelected] = useState<number | null>(null)
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [note, setNote] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+  const [gone, setGone] = useState(false)
+
+  const localTz = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, [])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!code) return
+    setStatus('loading')
+    getAvailability(code)
+      .then((r) => {
+        if (cancelled) return
+        setHost(r.host)
+        setSlots(r.slots)
+        setStatus('ready')
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setStatus(e.message === 'not-found' ? 'not-found' : 'error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [code])
+
+  const dayFmt = useMemo(
+    () => new Intl.DateTimeFormat(locale === 'ar' ? 'ar-SA' : 'en-GB', { weekday: 'long', day: 'numeric', month: 'long' }),
+    [locale],
+  )
+  const timeFmt = useMemo(
+    () => new Intl.DateTimeFormat(locale === 'ar' ? 'ar-SA' : 'en-GB', { hour: '2-digit', minute: '2-digit' }),
+    [locale],
+  )
+
+  // Group slots by the booker's local calendar day.
+  const grouped = useMemo(() => {
+    const byDay = new Map<string, number[]>()
+    for (const ms of slots) {
+      const key = new Date(ms).toDateString()
+      if (!byDay.has(key)) byDay.set(key, [])
+      byDay.get(key)!.push(ms)
+    }
+    return [...byDay.entries()]
+  }, [slots])
+
+  async function submit() {
+    if (!code || selected == null || !name.trim() || !email.trim()) return
+    setSubmitting(true)
+    setGone(false)
+    try {
+      const r = await book({ code, startUtc: selected, name: name.trim(), email: email.trim(), note: note.trim() })
+      if (r.conflict) {
+        // Slot taken — drop it and bounce back to the list.
+        setSlots((prev) => prev.filter((x) => x !== selected))
+        setSelected(null)
+        setGone(true)
+      } else if (r.ok) {
+        setDone(true)
+      }
+    } catch {
+      setGone(false)
+      setStatus('error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const heading = host?.name ? s.withMe(host.name) : s.withHost
+
+  return (
+    <div className="wrap py-[clamp(1.5rem,4vw,2.5rem)] max-w-[46rem] animate-[fadeUp_0.5s_ease_both]">
+      {status === 'loading' && <p className="text-ink-faint">{s.loading}</p>}
+      {status === 'not-found' && <Panel><p className="text-ink-soft">{s.notFound}</p></Panel>}
+      {status === 'error' && <Panel><p className="text-ink-soft">{s.error}</p></Panel>}
+
+      {status === 'ready' && host && (
+        <Stack>
+          <div className="flex flex-col gap-1">
+            <h1 className="font-display text-[clamp(1.5rem,4vw,2rem)] text-ink">{heading}</h1>
+            <div className="flex flex-wrap items-center gap-2 text-[0.9rem] text-ink-soft">
+              <Pill>{host.title}</Pill>
+              <span className="font-mono">{host.minutes} {s.mins}</span>
+              {host.location && <span className="text-ink-faint">· {host.location}</span>}
+            </div>
+          </div>
+
+          {done ? (
+            <Panel data-testid="booking-done">
+              <h2 className="font-display text-[1.4rem] text-green-700">{s.booked}</h2>
+              <p className="text-ink-soft">{s.bookedBody}</p>
+              <p className="text-ink-faint text-[0.9rem]">
+                {selected != null && `${dayFmt.format(new Date(selected))} ${s.at} ${timeFmt.format(new Date(selected))}`}
+              </p>
+            </Panel>
+          ) : selected == null ? (
+            <>
+              <p className="text-[0.85rem] text-ink-faint">{s.yourTz(localTz)}</p>
+              {gone && (
+                <p className="text-[0.9rem] text-gold-500" role="status">{s.gone}</p>
+              )}
+              {grouped.length === 0 ? (
+                <Panel><p className="text-ink-soft">{s.none}</p></Panel>
+              ) : (
+                <Stack>
+                  {grouped.map(([key, times]) => (
+                    <div key={key} className="flex flex-col gap-2">
+                      <h2 className="text-[0.95rem] font-semibold text-ink">{dayFmt.format(new Date(times[0]))}</h2>
+                      <div className="flex flex-wrap gap-2">
+                        {times.map((ms) => (
+                          <button
+                            key={ms}
+                            data-testid="slot"
+                            onClick={() => { setSelected(ms); setGone(false) }}
+                            className="font-mono text-[0.9rem] px-3 py-2 rounded-md border border-[color:var(--line)] bg-[var(--surface)] text-ink-soft hover:border-green-600 hover:text-green-700 transition-colors"
+                          >
+                            {timeFmt.format(new Date(ms))}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </Stack>
+              )}
+            </>
+          ) : (
+            <Panel>
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-semibold text-ink">
+                  {dayFmt.format(new Date(selected))} · {timeFmt.format(new Date(selected))}
+                </span>
+                <Button onClick={() => setSelected(null)}>{s.back}</Button>
+              </div>
+              <Field label={s.name}>
+                <Input value={name} data-testid="booker-name" onChange={(e) => setName(e.target.value)} autoFocus />
+              </Field>
+              <Field label={s.email}>
+                <Input type="email" value={email} data-testid="booker-email" onChange={(e) => setEmail(e.target.value)} />
+              </Field>
+              <Field label={s.note}>
+                <Textarea value={note} onChange={(e) => setNote(e.target.value)} />
+              </Field>
+              <Button
+                variant="primary"
+                data-testid="confirm-booking"
+                disabled={submitting || !name.trim() || !email.trim()}
+                onClick={submit}
+              >
+                {submitting ? s.booking : s.confirm}
+              </Button>
+            </Panel>
+          )}
+        </Stack>
+      )}
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,8 +17,9 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage />, errorElement: <ErrorPage /> },
       { path: 'tools/:toolId', element: <ToolPage />, errorElement: <ErrorPage /> },
-      // Public booking page. Also served at book-a-meeting.built-in-saudi.com/<code>
-      // (Cloudflare Pages rewrites the subdomain root to /<locale>/book/<code>).
+      // Public booking page. Shared as built-in-saudi.com/book/<code> — a bare
+      // /book/<code> hits Layout with an invalid :lang and redirects to the
+      // visitor's locale (/en|/ar), so booking links aren't language-locked.
       { path: 'book/:code', element: <BookingPage />, errorElement: <ErrorPage /> },
       { path: '*', element: <NotFoundPage /> },
     ],

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,6 +3,7 @@ import { Layout } from './components/Layout'
 import { RootRedirect } from './components/RootRedirect'
 import { HomePage } from './pages/HomePage'
 import { ToolPage } from './pages/ToolPage'
+import { BookingPage } from './pages/BookingPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { ErrorPage } from './components/ErrorPage'
 
@@ -16,6 +17,9 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage />, errorElement: <ErrorPage /> },
       { path: 'tools/:toolId', element: <ToolPage />, errorElement: <ErrorPage /> },
+      // Public booking page. Also served at book-a-meeting.built-in-saudi.com/<code>
+      // (Cloudflare Pages rewrites the subdomain root to /<locale>/book/<code>).
+      { path: 'book/:code', element: <BookingPage />, errorElement: <ErrorPage /> },
       { path: '*', element: <NotFoundPage /> },
     ],
   },

--- a/src/tools/book-with-me/AvailabilityGrid.tsx
+++ b/src/tools/book-with-me/AvailabilityGrid.tsx
@@ -1,0 +1,156 @@
+import { useRef, useState } from 'react'
+import { DAYS, ROWS, rowToMinutes, minutesToHHMM, type Grid } from './lib'
+
+interface Cell {
+  day: number
+  row: number
+}
+
+interface Drag {
+  anchor: Cell
+  current: Cell
+  mode: 'paint' | 'erase'
+}
+
+const DAY_LABELS = {
+  en: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  ar: ['أحد', 'إثن', 'ثلا', 'أرب', 'خمي', 'جمع', 'سبت'],
+}
+
+function inRect(d: Drag, day: number, row: number): boolean {
+  const [d0, d1] = [Math.min(d.anchor.day, d.current.day), Math.max(d.anchor.day, d.current.day)]
+  const [r0, r1] = [Math.min(d.anchor.row, d.current.row), Math.max(d.anchor.row, d.current.row)]
+  return day >= d0 && day <= d1 && row >= r0 && row <= r1
+}
+
+/** Read the {day,row} cell under a pointer via the elementFromPoint dataset. */
+function cellAt(x: number, y: number): Cell | null {
+  const el = document.elementFromPoint(x, y) as HTMLElement | null
+  const c = el?.closest<HTMLElement>('[data-day]')
+  if (!c || c.dataset.day === undefined || c.dataset.row === undefined) return null
+  return { day: Number(c.dataset.day), row: Number(c.dataset.row) }
+}
+
+export function AvailabilityGrid({
+  grid,
+  onChange,
+  locale,
+}: {
+  grid: Grid
+  onChange: (next: Grid) => void
+  locale: 'en' | 'ar'
+}) {
+  const [drag, setDrag] = useState<Drag | null>(null)
+  const dragRef = useRef<Drag | null>(null)
+  const days = DAY_LABELS[locale]
+
+  function begin(cell: Cell) {
+    const mode: Drag['mode'] = grid[cell.day][cell.row] ? 'erase' : 'paint'
+    const d: Drag = { anchor: cell, current: cell, mode }
+    dragRef.current = d
+    setDrag(d)
+  }
+
+  function extend(cell: Cell) {
+    const d = dragRef.current
+    if (!d) return
+    if (d.current.day === cell.day && d.current.row === cell.row) return
+    const next = { ...d, current: cell }
+    dragRef.current = next
+    setDrag(next)
+  }
+
+  function commit() {
+    const d = dragRef.current
+    dragRef.current = null
+    setDrag(null)
+    if (!d) return
+    const next = grid.map((col) => col.slice())
+    const paint = d.mode === 'paint'
+    for (let day = 0; day < DAYS; day++)
+      for (let row = 0; row < ROWS; row++) if (inRect(d, day, row)) next[day][row] = paint
+    onChange(next)
+  }
+
+  return (
+    <div className="select-none" data-testid="availability-grid">
+      <div
+        className="grid touch-none"
+        style={{ gridTemplateColumns: `3.2rem repeat(${DAYS}, minmax(0, 1fr))` }}
+        onPointerDown={(e) => {
+          const cell = cellAt(e.clientX, e.clientY)
+          if (!cell) return
+          e.preventDefault()
+          ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+          begin(cell)
+        }}
+        onPointerMove={(e) => {
+          if (!dragRef.current) return
+          const cell = cellAt(e.clientX, e.clientY)
+          if (cell) extend(cell)
+        }}
+        onPointerUp={commit}
+        onPointerCancel={commit}
+      >
+        {/* header row */}
+        <div className="sticky top-0 z-10 bg-[color:var(--surface)]" />
+        {days.map((d, i) => (
+          <div
+            key={i}
+            className="sticky top-0 z-10 bg-[color:var(--surface)] pb-2 text-center text-[0.78rem] font-semibold text-ink-soft"
+          >
+            {d}
+          </div>
+        ))}
+
+        {/* body: one CSS row per 30-min slot */}
+        {Array.from({ length: ROWS }, (_, row) => {
+          const isHour = rowToMinutes(row) % 60 === 0
+          return (
+            <div key={row} className="contents">
+              <div
+                className={`pe-2 text-end text-[0.68rem] leading-none tabular-nums text-ink-faint ${
+                  isHour ? '' : 'opacity-0'
+                }`}
+                style={{ transform: 'translateY(-0.4em)' }}
+              >
+                {isHour ? minutesToHHMM(rowToMinutes(row)) : ''}
+              </div>
+              {Array.from({ length: DAYS }, (_, day) => {
+                const on = grid[day][row]
+                const preview = drag && inRect(drag, day, row)
+                const painting = preview && drag!.mode === 'paint'
+                const erasing = preview && drag!.mode === 'erase'
+                const active = erasing ? false : painting ? true : on
+                return (
+                  <div
+                    key={day}
+                    data-day={day}
+                    data-row={row}
+                    data-testid={`cell-${day}-${row}`}
+                    aria-label={`${days[day]} ${minutesToHHMM(rowToMinutes(row))}`}
+                    className={[
+                      'h-4 cursor-crosshair border-[color:var(--line-soft)]',
+                      day === 0 ? 'border-s' : '',
+                      'border-e border-b',
+                      isHour ? 'border-t border-t-[color:var(--line)]' : '',
+                      active
+                        ? 'bg-[color-mix(in_srgb,var(--green-400)_42%,transparent)]'
+                        : 'bg-transparent hover:bg-[color-mix(in_srgb,var(--green-400)_12%,transparent)]',
+                      preview ? 'outline outline-1 outline-green-600' : '',
+                    ].join(' ')}
+                  />
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+      <p className="mt-2 text-[0.8rem] text-ink-faint">
+        {locale === 'ar'
+          ? 'اسحب لرسم أوقات فراغك · اسحب فوق وقت مُحدَّد لمسحه'
+          : 'Drag to paint when you’re free · drag over a filled block to erase.'}
+      </p>
+    </div>
+  )
+}

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -10,6 +10,7 @@ import {
   gridToWindows,
   windowsToGrid,
   BOOKING_LINK_BASE,
+  TELEGRAM_BOT,
   type HostConfig,
   type Grid,
 } from './lib'
@@ -63,6 +64,7 @@ const STR = {
     push: 'Push to this device',
     telegram: 'Telegram DM',
     email: 'Email',
+    linkTg: 'Link my Telegram',
     notifyNote: 'Push and Telegram activate after the backend deploy; email confirmations are on by default.',
     soon: 'Availability & settings save on this device until you publish.',
     publish: 'Publish & connect Google Calendar',
@@ -97,6 +99,7 @@ const STR = {
     push: 'إشعار لهذا الجهاز',
     telegram: 'رسالة تيليجرام',
     email: 'بريد إلكتروني',
+    linkTg: 'اربط تيليجرام',
     notifyNote: 'الإشعارات وتيليجرام تُفعَّل بعد نشر الخادم؛ تأكيدات البريد مفعّلة افتراضيًا.',
     soon: 'تُحفظ الأوقات والإعدادات على هذا الجهاز حتى تنشرها.',
     publish: 'انشر واربط تقويم جوجل',
@@ -307,11 +310,23 @@ export default function BookWithMeTool() {
               onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, push: e.target.checked } }))} />
             {s.push}
           </Check>
-          <Check>
-            <input type="checkbox" checked={cfg.notify.telegram}
-              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, telegram: e.target.checked } }))} />
-            {s.telegram}
-          </Check>
+          <div className="flex flex-wrap items-center gap-3">
+            <Check>
+              <input type="checkbox" checked={cfg.notify.telegram}
+                onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, telegram: e.target.checked } }))} />
+              {s.telegram}
+            </Check>
+            {cfg.notify.telegram && (
+              <Button
+                href={`https://t.me/${TELEGRAM_BOT}?start=${cfg.code}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="link-telegram"
+              >
+                {s.linkTg}
+              </Button>
+            )}
+          </div>
           <Check>
             <input type="checkbox" checked={cfg.notify.email}
               onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, email: e.target.checked } }))} />

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -9,7 +9,7 @@ import {
   saveConfig,
   gridToWindows,
   windowsToGrid,
-  BOOKING_ORIGIN,
+  BOOKING_LINK_BASE,
   type HostConfig,
   type Grid,
 } from './lib'
@@ -141,7 +141,7 @@ export default function BookWithMeTool() {
     saveConfig(cfg)
   }, [cfg])
 
-  const link = `${BOOKING_ORIGIN}/${cfg.code}`
+  const link = `${BOOKING_LINK_BASE}/${cfg.code}`
 
   function updateGrid(next: Grid) {
     setGrid(next)

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useLocale } from '../../i18n'
+import { CopyIcon } from '../../components/icons'
+import { Button, Input, Field, Stack, Seg, SegButton, Panel, Check } from '../../components/ui'
+import { AvailabilityGrid } from './AvailabilityGrid'
+import { connectGoogleUrl, saveSchedule } from '../../lib/bookingApi'
+import {
+  loadConfig,
+  saveConfig,
+  gridToWindows,
+  windowsToGrid,
+  BOOKING_ORIGIN,
+  type HostConfig,
+  type Grid,
+} from './lib'
+
+const HSID_KEY = 'bis-bookwith-hsid'
+
+interface Session {
+  hsid: string
+  email?: string
+  name?: string
+}
+
+/** Decode our HMAC session token's (base64url) payload for display only. */
+function readSession(): Session | null {
+  try {
+    const hsid = localStorage.getItem(HSID_KEY)
+    if (!hsid) return null
+    const b64 = hsid.split('.')[0].replace(/-/g, '+').replace(/_/g, '/')
+    const body = JSON.parse(atob(b64.padEnd(Math.ceil(b64.length / 4) * 4, '=')))
+    if (body.exp && Date.now() > body.exp) {
+      localStorage.removeItem(HSID_KEY)
+      return null
+    }
+    return { hsid, email: body.email, name: body.name }
+  } catch {
+    return null
+  }
+}
+
+const STR = {
+  en: {
+    intro: 'Set when you’re free, share one link, let people self-book. Your schedule is saved on this device.',
+    availability: 'Your weekly availability',
+    meeting: 'Meeting settings',
+    length: 'Length',
+    min: 'min',
+    gap: 'Gap between meetings',
+    notice: 'Minimum notice',
+    hours: 'hours',
+    horizon: 'Bookable up to',
+    days: 'days ahead',
+    title: 'Meeting title',
+    titlePh: 'Intro call',
+    location: 'Location / link',
+    locationPh: 'Google Meet, phone, address…',
+    share: 'Your booking link',
+    shareNote: 'Goes live once publishing is enabled. Anyone with the link can pick an open slot — no account needed.',
+    copy: 'Copy link',
+    copied: 'Copied!',
+    notify: 'Notify me when someone books',
+    push: 'Push to this device',
+    telegram: 'Telegram DM',
+    email: 'Email',
+    notifyNote: 'Push and Telegram activate after the backend deploy; email confirmations are on by default.',
+    soon: 'Availability & settings save on this device until you publish.',
+    publish: 'Publish & connect Google Calendar',
+    publishNote: 'Connect once to sign in, check your real calendar for conflicts, and auto-add booked meetings. Your link goes live immediately.',
+    connectedAs: (who: string) => `Connected as ${who}`,
+    published: 'Published',
+    save: 'Save changes',
+    saving: 'Saving…',
+    saved: 'Saved ✓',
+    saveErr: 'Couldn’t save — try again.',
+  },
+  ar: {
+    intro: 'حدِّد أوقات فراغك، وشارك رابطًا واحدًا، ودَع الناس يحجزون بأنفسهم. جدولك محفوظ على هذا الجهاز.',
+    availability: 'أوقات فراغك الأسبوعية',
+    meeting: 'إعدادات الاجتماع',
+    length: 'المدة',
+    min: 'دقيقة',
+    gap: 'فاصل بين الاجتماعات',
+    notice: 'أقل مهلة للحجز',
+    hours: 'ساعات',
+    horizon: 'الحجز حتى',
+    days: 'يومًا مقدمًا',
+    title: 'عنوان الاجتماع',
+    titlePh: 'مكالمة تعارف',
+    location: 'المكان / الرابط',
+    locationPh: 'Google Meet، هاتف، عنوان…',
+    share: 'رابط الحجز الخاص بك',
+    shareNote: 'يعمل بعد تفعيل النشر. أي شخص لديه الرابط يختار وقتًا متاحًا — دون حساب.',
+    copy: 'نسخ الرابط',
+    copied: 'تم النسخ!',
+    notify: 'نبّهني عند الحجز',
+    push: 'إشعار لهذا الجهاز',
+    telegram: 'رسالة تيليجرام',
+    email: 'بريد إلكتروني',
+    notifyNote: 'الإشعارات وتيليجرام تُفعَّل بعد نشر الخادم؛ تأكيدات البريد مفعّلة افتراضيًا.',
+    soon: 'تُحفظ الأوقات والإعدادات على هذا الجهاز حتى تنشرها.',
+    publish: 'انشر واربط تقويم جوجل',
+    publishNote: 'اربط مرة واحدة لتسجيل الدخول، والتحقق من تعارضات تقويمك الحقيقي، وإضافة الاجتماعات المحجوزة تلقائيًا. يعمل رابطك فورًا.',
+    connectedAs: (who: string) => `متصل باسم ${who}`,
+    published: 'منشور',
+    save: 'حفظ التغييرات',
+    saving: 'جارٍ الحفظ…',
+    saved: 'تم الحفظ ✓',
+    saveErr: 'تعذّر الحفظ — حاول مرة أخرى.',
+  },
+}
+
+const LENGTHS = [15, 30, 45, 60]
+
+export default function BookWithMeTool() {
+  const { locale } = useLocale()
+  const s = STR[locale]
+  const [cfg, setCfg] = useState<HostConfig>(() => loadConfig())
+  const [grid, setGrid] = useState<Grid>(() => windowsToGrid(cfg.availability))
+  const [copied, setCopied] = useState(false)
+  const [session, setSession] = useState<Session | null>(null)
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  // On return from the Google OAuth callback the dashboard URL carries
+  // #hsid=<session>&code=<hostCode>. Capture it, then clear the hash.
+  useEffect(() => {
+    const hash = window.location.hash
+    if (hash.startsWith('#hsid=')) {
+      const p = new URLSearchParams(hash.slice(1))
+      const hsid = p.get('hsid')
+      const code = p.get('code')
+      if (hsid) localStorage.setItem(HSID_KEY, hsid)
+      if (code) setCfg((c) => ({ ...c, code }))
+      history.replaceState(null, '', window.location.pathname + window.location.search)
+    }
+    setSession(readSession())
+  }, [])
+
+  // Persist locally whenever config changes.
+  useEffect(() => {
+    saveConfig(cfg)
+  }, [cfg])
+
+  const link = `${BOOKING_ORIGIN}/${cfg.code}`
+
+  function updateGrid(next: Grid) {
+    setGrid(next)
+    setCfg((c) => ({ ...c, availability: gridToWindows(next) }))
+  }
+
+  function setMeeting<K extends keyof HostConfig['meeting']>(key: K, val: HostConfig['meeting'][K]) {
+    setCfg((c) => ({ ...c, meeting: { ...c.meeting, [key]: val } }))
+  }
+
+  const isCustomLength = useMemo(() => !LENGTHS.includes(cfg.meeting.minutes), [cfg.meeting.minutes])
+
+  async function publish() {
+    if (!session) {
+      // Full-page redirect to Google (sign-in + calendar). Returns to this page
+      // with the #hsid session, handled by the effect above.
+      window.location.href = connectGoogleUrl(cfg.code, locale)
+      return
+    }
+    setSaveState('saving')
+    try {
+      await saveSchedule({
+        hsid: session.hsid,
+        code: cfg.code,
+        tz: cfg.tz,
+        meeting: cfg.meeting,
+        availability: cfg.availability,
+        notify: cfg.notify,
+      })
+      setSaveState('saved')
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch {
+      setSaveState('error')
+    }
+  }
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(link)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <Stack data-testid="book-with-me">
+      <p className="text-[0.95rem] text-ink-soft">{s.intro}</p>
+
+      {/* Publish / connect Google */}
+      <Panel>
+        {session ? (
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-col gap-0.5">
+              <span className="inline-flex items-center gap-2 text-[0.9rem] font-semibold text-green-700">
+                <span className="size-2 rounded-full bg-green-600" /> {s.published}
+              </span>
+              <span className="text-[0.82rem] text-ink-faint">{s.connectedAs(session.email || session.name || '')}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {saveState === 'error' && <span className="text-[0.82rem] text-gold-500">{s.saveErr}</span>}
+              <Button variant="primary" onClick={publish} disabled={saveState === 'saving'} data-testid="save-schedule">
+                {saveState === 'saving' ? s.saving : saveState === 'saved' ? s.saved : s.save}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <Button variant="primary" className="self-start" onClick={publish} data-testid="connect-google">
+              {s.publish}
+            </Button>
+            <p className="text-[0.82rem] text-ink-faint">{s.publishNote}</p>
+          </div>
+        )}
+      </Panel>
+
+      {/* Availability painter — the centerpiece */}
+      <Panel>
+        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.availability}</span>
+        <AvailabilityGrid grid={grid} onChange={updateGrid} locale={locale} />
+      </Panel>
+
+      {/* Meeting settings */}
+      <Panel>
+        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.meeting}</span>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-[0.82rem] font-semibold text-ink-soft">{s.length}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <Seg role="group">
+              {LENGTHS.map((n) => (
+                <SegButton
+                  key={n}
+                  active={cfg.meeting.minutes === n}
+                  data-testid={`length-${n}`}
+                  onClick={() => setMeeting('minutes', n)}
+                >
+                  {n} {s.min}
+                </SegButton>
+              ))}
+            </Seg>
+            <Input
+              className="font-mono w-24"
+              type="number"
+              min="5"
+              step="5"
+              aria-label={s.length}
+              value={isCustomLength ? cfg.meeting.minutes : ''}
+              placeholder="…"
+              onChange={(e) => setMeeting('minutes', Math.max(5, Number(e.target.value) || 5))}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Field label={`${s.gap} (${s.min})`}>
+            <Input className="font-mono" type="number" min="0" step="5" value={cfg.meeting.gapMinutes}
+              data-testid="gap"
+              onChange={(e) => setMeeting('gapMinutes', Math.max(0, Number(e.target.value) || 0))} />
+          </Field>
+          <Field label={`${s.notice} (${s.hours})`}>
+            <Input className="font-mono" type="number" min="0" value={cfg.meeting.minNoticeHours}
+              onChange={(e) => setMeeting('minNoticeHours', Math.max(0, Number(e.target.value) || 0))} />
+          </Field>
+          <Field label={`${s.horizon} (${s.days})`}>
+            <Input className="font-mono" type="number" min="1" value={cfg.meeting.horizonDays}
+              onChange={(e) => setMeeting('horizonDays', Math.max(1, Number(e.target.value) || 1))} />
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Field label={s.title}>
+            <Input value={cfg.meeting.title} placeholder={s.titlePh}
+              onChange={(e) => setMeeting('title', e.target.value)} />
+          </Field>
+          <Field label={s.location}>
+            <Input value={cfg.meeting.location} placeholder={s.locationPh}
+              onChange={(e) => setMeeting('location', e.target.value)} />
+          </Field>
+        </div>
+      </Panel>
+
+      {/* Share link */}
+      <Panel>
+        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.share}</span>
+        <div className="flex flex-wrap gap-2">
+          <Input className="font-mono grow min-w-0 text-[0.85rem]" readOnly value={link}
+            data-testid="booking-link" onFocus={(e) => e.currentTarget.select()} />
+          <Button variant="primary" onClick={copyLink} data-testid="copy-link">
+            <CopyIcon /> {copied ? s.copied : s.copy}
+          </Button>
+        </div>
+        <p className="text-[0.82rem] text-ink-faint">{s.shareNote}</p>
+      </Panel>
+
+      {/* Notifications */}
+      <Panel>
+        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.notify}</span>
+        <div className="flex flex-col gap-2">
+          <Check>
+            <input type="checkbox" checked={cfg.notify.push}
+              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, push: e.target.checked } }))} />
+            {s.push}
+          </Check>
+          <Check>
+            <input type="checkbox" checked={cfg.notify.telegram}
+              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, telegram: e.target.checked } }))} />
+            {s.telegram}
+          </Check>
+          <Check>
+            <input type="checkbox" checked={cfg.notify.email}
+              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, email: e.target.checked } }))} />
+            {s.email}
+          </Check>
+        </div>
+        <p className="text-[0.82rem] text-ink-faint">{s.notifyNote}</p>
+      </Panel>
+
+      <p className="text-[0.82rem] text-ink-faint">{s.soon}</p>
+    </Stack>
+  )
+}

--- a/src/tools/book-with-me/lib.ts
+++ b/src/tools/book-with-me/lib.ts
@@ -1,0 +1,199 @@
+// Shared types + slot math for Book With Me. The Firestore doc shape mirrors
+// HostConfig (see docs/tools/book-with-me.md); until the backend is live the
+// host dashboard persists this to localStorage under BIS_KEY.
+
+export interface AvailWindow {
+  day: number // 0 = Sunday … 6 = Saturday (host-tz local)
+  start: string // 'HH:MM'
+  end: string // 'HH:MM' (exclusive)
+}
+
+export interface MeetingConfig {
+  minutes: number // meeting length
+  gapMinutes: number // gap between consecutive meetings
+  bufferBefore: number
+  bufferAfter: number
+  horizonDays: number // how far ahead people can book
+  minNoticeHours: number // earliest a slot can be booked from now
+  title: string
+  location: string
+}
+
+export interface HostConfig {
+  code: string
+  tz: string
+  meeting: MeetingConfig
+  availability: AvailWindow[]
+  notify: { push: boolean; telegram: boolean; email: boolean }
+}
+
+// ---- Grid geometry ----------------------------------------------------------
+
+export const DAY_START_MIN = 6 * 60 // grid starts at 06:00
+export const DAY_END_MIN = 24 * 60 // …ends at 24:00
+export const SLOT_MIN = 30 // one grid row = 30 minutes
+export const ROWS = (DAY_END_MIN - DAY_START_MIN) / SLOT_MIN // 36
+export const DAYS = 7
+
+export type Grid = boolean[][] // [day 0..6][row 0..ROWS-1]
+
+export function emptyGrid(): Grid {
+  return Array.from({ length: DAYS }, () => Array<boolean>(ROWS).fill(false))
+}
+
+export function rowToMinutes(row: number): number {
+  return DAY_START_MIN + row * SLOT_MIN
+}
+
+export function minutesToHHMM(min: number): string {
+  const h = Math.floor(min / 60)
+  const m = min % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+function hhmmToMinutes(s: string): number {
+  const [h, m] = s.split(':').map(Number)
+  return h * 60 + m
+}
+
+// ---- Grid <-> availability windows -----------------------------------------
+
+/** Merge consecutive painted rows per day into [start,end) windows. */
+export function gridToWindows(grid: Grid): AvailWindow[] {
+  const out: AvailWindow[] = []
+  for (let day = 0; day < DAYS; day++) {
+    let runStart = -1
+    for (let row = 0; row <= ROWS; row++) {
+      const on = row < ROWS && grid[day][row]
+      if (on && runStart === -1) runStart = row
+      else if (!on && runStart !== -1) {
+        out.push({
+          day,
+          start: minutesToHHMM(rowToMinutes(runStart)),
+          end: minutesToHHMM(rowToMinutes(row)),
+        })
+        runStart = -1
+      }
+    }
+  }
+  return out
+}
+
+export function windowsToGrid(windows: AvailWindow[]): Grid {
+  const grid = emptyGrid()
+  for (const w of windows) {
+    const from = Math.max(0, Math.round((hhmmToMinutes(w.start) - DAY_START_MIN) / SLOT_MIN))
+    const to = Math.min(ROWS, Math.round((hhmmToMinutes(w.end) - DAY_START_MIN) / SLOT_MIN))
+    for (let row = from; row < to; row++) if (grid[w.day]) grid[w.day][row] = true
+  }
+  return grid
+}
+
+// ---- Slot enumeration (used by the booking page) ----------------------------
+
+export interface Slot {
+  startUtc: number // epoch ms
+  endUtc: number
+}
+
+/**
+ * Enumerate bookable slot start times inside a day's availability windows,
+ * stepping by (meeting length + gap). `busy` ranges (existing bookings / Google
+ * free-busy, epoch-ms) are subtracted. Times are computed in the host tz using
+ * the provided day-in-tz midnight epoch as the anchor.
+ */
+export function enumerateDaySlots(
+  windows: AvailWindow[],
+  dayMidnightUtc: number,
+  meeting: MeetingConfig,
+  busy: { start: number; end: number }[],
+  now: number,
+): Slot[] {
+  const step = (meeting.minutes + meeting.gapMinutes) * 60_000
+  const len = meeting.minutes * 60_000
+  const earliest = now + meeting.minNoticeHours * 3_600_000
+  const slots: Slot[] = []
+  for (const w of windows) {
+    const winStart = dayMidnightUtc + hhmmToMinutes(w.start) * 60_000
+    const winEnd = dayMidnightUtc + hhmmToMinutes(w.end) * 60_000
+    for (let s = winStart; s + len <= winEnd + 1; s += step) {
+      const e = s + len
+      if (s < earliest) continue
+      const clash = busy.some((b) => s < b.end && e > b.start)
+      if (!clash) slots.push({ startUtc: s, endUtc: e })
+    }
+  }
+  return slots
+}
+
+// ---- Defaults + persistence -------------------------------------------------
+
+export const BIS_KEY = 'bis-bookwith'
+
+export function defaultMeeting(): MeetingConfig {
+  return {
+    minutes: 45,
+    gapMinutes: 0,
+    bufferBefore: 0,
+    bufferAfter: 0,
+    horizonDays: 30,
+    minNoticeHours: 4,
+    title: 'Meeting',
+    location: '',
+  }
+}
+
+/** Short URL-safe booking code (no ambiguous chars). */
+export function makeCode(): string {
+  const alphabet = 'abcdefghjkmnpqrstuvwxyz23456789'
+  const bytes = new Uint8Array(7)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => alphabet[b % alphabet.length]).join('')
+}
+
+export function defaultConfig(): HostConfig {
+  return {
+    code: makeCode(),
+    tz: Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Riyadh',
+    meeting: defaultMeeting(),
+    availability: [
+      // A sensible starter: weekday mornings, so the grid isn't blank.
+      { day: 1, start: '09:00', end: '12:00' },
+      { day: 2, start: '09:00', end: '12:00' },
+      { day: 3, start: '09:00', end: '12:00' },
+      { day: 4, start: '09:00', end: '12:00' },
+      { day: 0, start: '10:00', end: '13:00' },
+    ],
+    notify: { push: false, telegram: false, email: true },
+  }
+}
+
+export function loadConfig(): HostConfig {
+  try {
+    const raw = localStorage.getItem(BIS_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<HostConfig>
+      return {
+        ...defaultConfig(),
+        ...parsed,
+        meeting: { ...defaultMeeting(), ...(parsed.meeting || {}) },
+        notify: { push: false, telegram: false, email: true, ...(parsed.notify || {}) },
+        // keep a stable code across reloads
+        code: parsed.code || makeCode(),
+      }
+    }
+  } catch {
+    /* ignore corrupt storage */
+  }
+  return defaultConfig()
+}
+
+export function saveConfig(cfg: HostConfig): void {
+  try {
+    localStorage.setItem(BIS_KEY, JSON.stringify(cfg))
+  } catch {
+    /* quota / private mode — non-fatal */
+  }
+}
+
+export const BOOKING_ORIGIN = 'https://book-a-meeting.built-in-saudi.com'

--- a/src/tools/book-with-me/lib.ts
+++ b/src/tools/book-with-me/lib.ts
@@ -200,3 +200,7 @@ export function saveConfig(cfg: HostConfig): void {
 // A bare /book/<code> lets the visitor's own locale kick in via the Layout
 // redirect, so links aren't language-locked.
 export const BOOKING_LINK_BASE = 'https://built-in-saudi.com/book'
+
+// Public Telegram bot handle (safe to expose). The dashboard deep-links to
+// t.me/<bot>?start=<code>; the telegramWebhook binds that chat to the host.
+export const TELEGRAM_BOT = 'BuiltInSaudi_bot'

--- a/src/tools/book-with-me/lib.ts
+++ b/src/tools/book-with-me/lib.ts
@@ -196,4 +196,7 @@ export function saveConfig(cfg: HostConfig): void {
   }
 }
 
-export const BOOKING_ORIGIN = 'https://book-a-meeting.built-in-saudi.com'
+// Path-based booking link on the apex (subdomain deferred — no Cloudflare needed).
+// A bare /book/<code> lets the visitor's own locale kick in via the Layout
+// redirect, so links aren't language-locked.
+export const BOOKING_LINK_BASE = 'https://built-in-saudi.com/book'

--- a/src/tools/book-with-me/meta.ts
+++ b/src/tools/book-with-me/meta.ts
@@ -1,0 +1,26 @@
+import { lazyTool } from '../../lib/lazyTool'
+import type { Tool } from '../types'
+import { CalendarCheckIcon } from '../../components/icons'
+
+export const bookWithMeTool: Tool = {
+  id: 'book-with-me',
+  name: 'Book With Me',
+  nameAr: 'احجز معي',
+  tagline: 'Share one link; let people self-book a meeting.',
+  description:
+    'A free, no-sign-up scheduling link — paint your weekly availability, set the meeting length (45 min by default) with gaps and buffers, and share one link. People pick an open slot without the email back-and-forth; you get a push, a Telegram DM and an email when they book.',
+  category: 'Business',
+  keywords: [
+    'calendly', 'booking', 'meeting', 'schedule', 'appointment', 'availability', 'calendar',
+    'book a meeting', 'حجز', 'اجتماع', 'موعد', 'جدولة', 'رابط حجز', 'كالندلي',
+  ],
+  status: 'beta',
+  Icon: CalendarCheckIcon,
+  component: lazyTool(() => import('./BookWithMeTool')),
+  ar: {
+    name: 'احجز معي',
+    tagline: 'شارك رابطًا واحدًا؛ ودَع الناس يحجزون معك.',
+    description:
+      'رابط جدولة مجاني بلا تسجيل — ارسم أوقات فراغك الأسبوعية، وحدِّد مدة الاجتماع (٤٥ دقيقة افتراضيًا) بفواصل ومهل، وشارك رابطًا واحدًا. يختار الناس وقتًا متاحًا دون تبادل رسائل، وتصلك إشعارات ورسالة تيليجرام وبريد عند الحجز.',
+  },
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -32,6 +32,7 @@ import { vatCalculatorTool } from './vat-calculator/meta'
 import { dateDiffTool } from './date-diff/meta'
 import { zipInspectorTool } from './zip-inspector/meta'
 import { metadataTool } from './metadata/meta'
+import { bookWithMeTool } from './book-with-me/meta'
 
 /**
  * The tool catalog. Stable/beta tools render inside the app at /tools/:id.
@@ -40,6 +41,7 @@ import { metadataTool } from './metadata/meta'
  * Order here is the order shown on the home catalog.
  */
 export const tools: Tool[] = [
+  bookWithMeTool,
   qrCodeTool,
   imageCompressorTool,
   imageFormatConverterTool,


### PR DESCRIPTION
New flagship tool: **Book With Me** — set your weekly availability, share one link, let people self-book.

## What's here
- **Host dashboard** (`src/tools/book-with-me/`) — drag-to-paint weekly availability grid, meeting config (45min default, gaps/buffers/horizon/min-notice), shareable link, push/Telegram/email toggles, and a **Publish & connect Google** button (OAuth `#hsid` session handshake wired).
- **Public booking page** (`src/pages/BookingPage.tsx`, route `/:lang/book/:code`) — fetches open slots, groups them in the booker's timezone, collects name/email/note, books.
- **Backend** (`functions/booking.js`) — 6 functions on the existing prayer-alerts stack, **no new npm deps** (Google/Resend/Telegram over `fetch`, HMAC sessions via `node:crypto`, hand-written `.ics`): OAuth sign-in + calendar free/busy + auto-created events, transactional double-booking guard, Web Push + Telegram DM + Resend email with `.ics`.
- Deploy wiring in `deploy-functions.yml`, docs in `docs/tools/book-with-me.md` + `functions/README.md`.

## ⚠️ Before merging / going live (owner setup)
Placeholder secrets/vars already created (`REPLACE_ME`): `GOOGLE_OAUTH_CLIENT_ID/SECRET`, `RESEND_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_USERNAME`.
1. Create the Google OAuth Web client (redirect `…/booking-google-callback`) + submit consent for verification. Calendar API already enabled ✅.
2. Verify `built-in-saudi.com` in Resend.
3. Create the Telegram bot; run `setWebhook` after first deploy.
4. Cloudflare Pages project + `book-a-meeting` subdomain CNAME.

The backend is **code-complete but untested against live Google/Resend/Telegram** — it needs a smoke test once the secrets land.

Typecheck ✅ · build ✅ (prerender 35 pages) · `node --check` on backend ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)