### PR TITLE
Book With Me redesign: hourly grid, publish/share, alerts pill, legal pages

### DIFF
--- a/functions/booking.js
+++ b/functions/booking.js
@@ -251,11 +251,19 @@ function openSlots(host, busy, now) {
   const tz = host.tz || 'Asia/Riyadh'
   const meeting = host.meeting || {}
   const windows = host.availability || []
-  const lenMs = (meeting.minutes || 45) * 60000
-  const stepMs = ((meeting.minutes || 45) + (meeting.gapMinutes || 0)) * 60000
+  const minutes = meeting.minutes || 45
+  const lenMs = minutes * 60000
+  const stepMs = (minutes + (meeting.gapMinutes || 0)) * 60000
   const earliest = now + (meeting.minNoticeHours || 0) * 3600000
   const horizonEnd = now + (meeting.horizonDays || 30) * 86400000
+  const HOUR = 3600000
   const slots = []
+  const add = (s) => {
+    if (s < earliest || s > horizonEnd) return
+    const e = s + lenMs
+    if (busy.some((b) => s < b.end && e > b.start)) return
+    slots.push(s)
+  }
   // Iterate calendar days in host tz from today until the horizon.
   for (let dayOffset = 0; dayOffset <= (meeting.horizonDays || 30) + 1; dayOffset++) {
     const probe = now + dayOffset * 86400000
@@ -264,11 +272,13 @@ function openSlots(host, busy, now) {
       if (w.day !== weekday) continue
       const winStart = zonedToUtc(y, m - 1, d, 0, 0, tz) + hhmmToMin(w.start) * 60000
       const winEnd = zonedToUtc(y, m - 1, d, 0, 0, tz) + hhmmToMin(w.end) * 60000
-      for (let s = winStart; s + lenMs <= winEnd + 1; s += stepMs) {
-        if (s < earliest || s > horizonEnd) continue
-        const e = s + lenMs
-        if (busy.some((b) => s < b.end && e > b.start)) continue
-        slots.push(s)
+      if (minutes > 60) {
+        // Long meetings span hour boundaries — step continuously.
+        for (let s = winStart; s + lenMs <= winEnd + 1; s += stepMs) add(s)
+      } else {
+        // Sessions align to each whole hour; leftover time is the gap.
+        for (let h = winStart; h < winEnd; h += HOUR)
+          for (let s = h; s + lenMs <= h + HOUR + 1; s += stepMs) add(s)
       }
     }
   }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,6 +16,8 @@ export function Footer() {
         </div>
         <nav className="flex gap-[1.3rem] items-start [&_a]:no-underline [&_a]:font-semibold [&_a]:text-ink-soft [&_a]:text-[0.92rem] [&_a:hover]:text-green-600" aria-label="Footer">
           <Link to={localePath(locale)} data-testid="footer-all-tools">{t.footer.allTools}</Link>
+          <Link to={localePath(locale, '/privacy')} data-testid="footer-privacy">{t.footer.privacy}</Link>
+          <Link to={localePath(locale, '/terms')} data-testid="footer-terms">{t.footer.terms}</Link>
           <a href="https://github.com/bjorn-ali-goransson/built-in-saudi" target="_blank" rel="noreferrer noopener" data-testid="footer-github">
             {t.footer.github}
           </a>

--- a/src/i18n/ar.ts
+++ b/src/i18n/ar.ts
@@ -36,6 +36,8 @@ export const ar: Dict = {
     allTools: 'كل التطبيقات',
     github: 'GitHub',
     reportIssue: 'أبلغ عن مشكلة',
+    privacy: 'الخصوصية',
+    terms: 'الشروط',
   },
 
   notif: {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -36,6 +36,8 @@ export const en = {
     allTools: 'All apps',
     github: 'GitHub',
     reportIssue: 'Report an issue',
+    privacy: 'Privacy',
+    terms: 'Terms',
   },
 
   notif: {

--- a/src/i18n/seo.ts
+++ b/src/i18n/seo.ts
@@ -22,6 +22,20 @@ export interface ToolSeo {
   ar: { name: string; description: string }
 }
 
+/** Standalone (non-tool) pages that also get prerendered at /<locale>/<id>/. */
+export const staticPageSeo: ToolSeo[] = [
+  {
+    id: 'privacy',
+    en: { name: 'Privacy Policy', description: 'How Built in Saudi handles your data: almost everything runs in your browser and never leaves your device; the Book With Me scheduling tool and its Google Calendar use are explained in full.' },
+    ar: { name: 'سياسة الخصوصية', description: 'كيف يتعامل «بُنِيَ في السعودية» مع بياناتك: يعمل كل شيء تقريبًا داخل متصفحك ولا يغادر جهازك؛ مع شرحٍ كامل لأداة «احجز معي» واستخدامها لتقويم جوجل.' },
+  },
+  {
+    id: 'terms',
+    en: { name: 'Terms of Use', description: 'The simple terms covering your use of Built in Saudi and its free tools, including Book With Me.' },
+    ar: { name: 'شروط الاستخدام', description: 'الشروط البسيطة التي تغطي استخدامك لـ«بُنِيَ في السعودية» وأدواته المجانية، بما في ذلك «احجز معي».' },
+  },
+]
+
 /** Live (routable) tools only — used to prerender /<locale>/tools/<id>/. */
 export const liveToolSeo: ToolSeo[] = [
   {

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -33,6 +33,27 @@ export async function currentSubscription(): Promise<PushSubscription | null> {
   return reg.pushManager.getSubscription()
 }
 
+/** Subscribe this device and return the raw PushSubscription (no server POST) —
+ *  for tools that store it elsewhere (Book With Me keeps it on the host record).
+ *  Returns null if unsupported or permission denied. */
+export async function subscribeDevice(): Promise<PushSubscription | null> {
+  if (!pushSupported()) return null
+  try {
+    const perm = await Notification.requestPermission()
+    if (perm !== 'granted') return null
+    const reg = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error('sw timeout')), 10000)),
+    ])
+    return await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC) as BufferSource,
+    })
+  } catch {
+    return null
+  }
+}
+
 export type EnableStatus = 'ok' | 'denied' | 'unsupported' | 'error'
 export interface EnableResult { status: EnableStatus; detail?: string }
 

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { useLocale } from '../i18n'
 import { useDocumentMeta } from '../lib/useDocumentMeta'
 import { Button, Input, Textarea, Field, Stack, Panel, Pill } from '../components/ui'
 import { getAvailability, book, type HostMeta } from '../lib/bookingApi'
+import { loadConfig, previewSlots } from '../tools/book-with-me/lib'
 
 const STR = {
   en: {
@@ -26,6 +27,8 @@ const STR = {
     bookedBody: 'A confirmation with a calendar invite is on its way to your email.',
     gone: 'That slot was just taken. Please pick another.',
     at: 'at',
+    previewBanner: 'Preview — this is exactly what visitors see. Bookings are disabled here.',
+    previewDisabled: 'Disabled in preview',
   },
   ar: {
     loading: 'جارٍ تحميل الأوقات…',
@@ -47,6 +50,8 @@ const STR = {
     bookedBody: 'رسالة تأكيد مع دعوة تقويم في طريقها إلى بريدك.',
     gone: 'حُجز هذا الوقت للتو. اختر وقتًا آخر.',
     at: 'الساعة',
+    previewBanner: 'معاينة — هذا تمامًا ما يراه الزوار. الحجز معطّل هنا.',
+    previewDisabled: 'معطّل في المعاينة',
   },
 }
 
@@ -54,6 +59,8 @@ type Status = 'loading' | 'ready' | 'not-found' | 'error'
 
 export function BookingPage() {
   const { code } = useParams()
+  const [searchParams] = useSearchParams()
+  const preview = searchParams.get('preview') === '1'
   const { locale } = useLocale()
   const s = STR[locale]
   useDocumentMeta(locale, `/book/${code}`)
@@ -73,6 +80,15 @@ export function BookingPage() {
 
   useEffect(() => {
     let cancelled = false
+    // Preview: render straight from the host's own saved config (same browser),
+    // no backend call — works before publishing/connecting Google.
+    if (preview) {
+      const cfg = loadConfig()
+      setHost({ name: null, tz: cfg.tz, minutes: cfg.meeting.minutes, title: cfg.meeting.title, location: cfg.meeting.location })
+      setSlots(previewSlots(cfg))
+      setStatus('ready')
+      return
+    }
     if (!code) return
     setStatus('loading')
     getAvailability(code)
@@ -89,7 +105,7 @@ export function BookingPage() {
     return () => {
       cancelled = true
     }
-  }, [code])
+  }, [code, preview])
 
   const dayFmt = useMemo(
     () => new Intl.DateTimeFormat(locale === 'ar' ? 'ar-SA' : 'en-GB', { weekday: 'long', day: 'numeric', month: 'long' }),
@@ -143,6 +159,11 @@ export function BookingPage() {
 
       {status === 'ready' && host && (
         <Stack>
+          {preview && (
+            <div className="border-s-2 border-gold-400 bg-[color-mix(in_srgb,var(--color-gold-400)_12%,transparent)] px-3 py-2 text-[0.85rem] text-ink-soft" role="status" data-testid="preview-banner">
+              {s.previewBanner}
+            </div>
+          )}
           <div className="flex flex-col gap-1">
             <h1 className="font-display text-[clamp(1.5rem,4vw,2rem)] text-ink">{heading}</h1>
             <div className="flex flex-wrap items-center gap-2 text-[0.9rem] text-ink-soft">
@@ -210,10 +231,10 @@ export function BookingPage() {
               <Button
                 variant="primary"
                 data-testid="confirm-booking"
-                disabled={submitting || !name.trim() || !email.trim()}
+                disabled={preview || submitting || !name.trim() || !email.trim()}
                 onClick={submit}
               >
-                {submitting ? s.booking : s.confirm}
+                {preview ? s.previewDisabled : submitting ? s.booking : s.confirm}
               </Button>
             </Panel>
           )}

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,0 +1,143 @@
+import { useLocale } from '../i18n'
+import { useDocumentMeta } from '../lib/useDocumentMeta'
+
+interface Section {
+  h: string
+  p: string[]
+}
+
+const STR: Record<'en' | 'ar', { title: string; updated: string; intro: string; sections: Section[] }> = {
+  en: {
+    title: 'Privacy Policy',
+    updated: 'Last updated: 6 July 2026',
+    intro:
+      'Built in Saudi is a toolbox of free, privacy-first online utilities. Our default is simple: almost every tool runs entirely in your browser, and your files and text never leave your device. This policy explains the few cases where data does reach our servers — chiefly the Book With Me scheduling tool — and exactly what we do with it.',
+    sections: [
+      {
+        h: 'Tools that run in your browser',
+        p: [
+          'The vast majority of our tools (image, PDF, text, converter, calculator and Saudi/Islamic utilities) are 100% client-side. The files and text you work with are processed on your device and are never uploaded to us. We cannot see them.',
+          'These tools may keep small preferences in your browser’s localStorage (for example your last-used settings). That never leaves your device.',
+        ],
+      },
+      {
+        h: 'Book With Me (the scheduling tool)',
+        p: [
+          'Book With Me needs a server to work, so it is our one clearly-badged exception. If you use it as a host, we store: your availability and meeting settings; your Google account’s basic profile (name, email, picture); a Google refresh token so we can check your calendar and add booked meetings; and, if you enable them, your push subscription and Telegram chat id.',
+          'When someone books with you, we store that booking: the person’s name, email, an optional note, and the meeting time. We use it to create the calendar event and send confirmations.',
+          'People who book with you provide their name and email only to make the booking. We use it solely to confirm and calendar the meeting — never for marketing.',
+        ],
+      },
+      {
+        h: 'Google user data',
+        p: [
+          'With your explicit consent, Book With Me uses the Google Calendar “events” and “free/busy” scopes for two purposes only: (1) to read your busy times so the booking page never offers a slot when you are busy, and (2) to create a calendar event when someone books with you. We store a refresh token to perform these actions on your behalf.',
+          'Built in Saudi’s use and transfer of information received from Google APIs adheres to the Google API Services User Data Policy, including the Limited Use requirements. We do not sell this data, do not use it for advertising, and do not share it with third parties except as needed to provide the feature (Google itself).',
+          'You can revoke our access at any time from your Google Account’s security settings (Third-party access), or by contacting us to delete your host record.',
+        ],
+      },
+      {
+        h: 'Email and notifications',
+        p: [
+          'Booking confirmations are sent by email through Resend (our email provider) and include a calendar invite. Optional booking alerts are sent via Web Push and, if you connect it, Telegram. These carry only the details needed for the notification.',
+        ],
+      },
+      {
+        h: 'Analytics',
+        p: [
+          'We use Google Analytics (GA4) to understand aggregate, anonymous usage — which tools are used and roughly where visitors come from. We do not use it to identify you and we do not sell analytics data.',
+        ],
+      },
+      {
+        h: 'Retention and deletion',
+        p: [
+          'Client-side tool data lives only in your browser until you clear it. For Book With Me, your host record and bookings are kept while your scheduling link is active. To delete your data, revoke Google access and email us and we will remove your host record and bookings.',
+        ],
+      },
+      {
+        h: 'Contact',
+        p: ['Questions or deletion requests: hello@built-in-saudi.com.'],
+      },
+    ],
+  },
+  ar: {
+    title: 'سياسة الخصوصية',
+    updated: 'آخر تحديث: ٦ يوليو ٢٠٢٦',
+    intro:
+      '«بُنِيَ في السعودية» صندوق أدوات مجانية تحترم خصوصيتك. الأصل بسيط: تعمل جميع الأدوات تقريبًا داخل متصفحك بالكامل، ولا تغادر ملفاتك ونصوصك جهازك. توضّح هذه السياسة الحالات القليلة التي تصل فيها بيانات إلى خوادمنا — خصوصًا أداة «احجز معي» — وما نفعله بها بالضبط.',
+    sections: [
+      {
+        h: 'أدوات تعمل داخل متصفحك',
+        p: [
+          'الغالبية العظمى من أدواتنا (الصور وPDF والنصوص والمحوّلات والحاسبات والأدوات السعودية والإسلامية) تعمل بالكامل على جهازك. تُعالَج ملفاتك ونصوصك محليًا ولا تُرفع إلينا أبدًا، ولا يمكننا رؤيتها.',
+          'قد تحفظ هذه الأدوات تفضيلات صغيرة في متصفحك (مثل آخر إعداداتك)، وهي لا تغادر جهازك.',
+        ],
+      },
+      {
+        h: 'أداة «احجز معي»',
+        p: [
+          'تحتاج «احجز معي» إلى خادم لتعمل، وهي استثناؤنا الوحيد الموسوم بوضوح. إن استخدمتها كمُضيف، نحفظ: أوقات فراغك وإعدادات الاجتماع؛ ومعلومات حسابك الأساسية في جوجل (الاسم والبريد والصورة)؛ ورمز تحديث من جوجل لنتحقق من تقويمك ونضيف الاجتماعات المحجوزة؛ وإن فعّلتها، اشتراك الإشعارات ومعرّف محادثة تيليجرام.',
+          'عندما يحجز أحدهم معك، نحفظ ذلك الحجز: اسم الشخص وبريده وملاحظة اختيارية ووقت الاجتماع، لإنشاء حدث التقويم وإرسال التأكيدات.',
+          'يقدّم من يحجزون معك أسماءهم وبريدهم لإتمام الحجز فقط، ونستخدمها حصريًا لتأكيد الموعد وجدولته — لا للتسويق.',
+        ],
+      },
+      {
+        h: 'بيانات مستخدم جوجل',
+        p: [
+          'بموافقتك الصريحة، تستخدم «احجز معي» صلاحيتَي «الأحداث» و«أوقات الانشغال» في تقويم جوجل لغرضين فقط: (١) قراءة أوقات انشغالك حتى لا تعرض صفحة الحجز وقتًا أنت مشغول فيه، و(٢) إنشاء حدث في التقويم عند الحجز. ونحفظ رمز تحديث للقيام بذلك نيابةً عنك.',
+          'يلتزم «بُنِيَ في السعودية» في استخدامه ونقله للمعلومات الواردة من واجهات جوجل بسياسة بيانات مستخدم خدمات واجهات جوجل، بما في ذلك متطلبات الاستخدام المحدود. لا نبيع هذه البيانات، ولا نستخدمها للإعلانات، ولا نشاركها مع أطراف ثالثة إلا بالقدر اللازم لتقديم الميزة (جوجل نفسها).',
+          'يمكنك إلغاء وصولنا في أي وقت من إعدادات أمان حساب جوجل (وصول الجهات الخارجية)، أو بمراسلتنا لحذف سجلك.',
+        ],
+      },
+      {
+        h: 'البريد والإشعارات',
+        p: [
+          'تُرسَل تأكيدات الحجز بالبريد عبر Resend (مزوّد البريد لدينا) وتتضمن دعوة تقويم. وتُرسَل التنبيهات الاختيارية عبر إشعارات الويب، وتيليجرام إن ربطته، ولا تحمل إلا تفاصيل الإشعار.',
+        ],
+      },
+      {
+        h: 'التحليلات',
+        p: [
+          'نستخدم Google Analytics (GA4) لفهم الاستخدام الإجمالي المجهول — أي الأدوات تُستخدم ومن أين يأتي الزوار تقريبًا. لا نستخدمه للتعرّف عليك ولا نبيع بيانات التحليلات.',
+        ],
+      },
+      {
+        h: 'الاحتفاظ والحذف',
+        p: [
+          'تبقى بيانات الأدوات في متصفحك حتى تمسحها. أما «احجز معي» فيُحفظ سجلك وحجوزاتك ما دام رابط الحجز نشطًا. لحذف بياناتك، ألغِ وصول جوجل وراسلنا وسنحذف سجلك وحجوزاتك.',
+        ],
+      },
+      {
+        h: 'التواصل',
+        p: ['للأسئلة أو طلبات الحذف: hello@built-in-saudi.com.'],
+      },
+    ],
+  },
+}
+
+export function PrivacyPage() {
+  const { locale } = useLocale()
+  const s = STR[locale]
+  useDocumentMeta(locale, '/privacy', s.title, s.intro.slice(0, 155))
+  return <LegalDoc title={s.title} updated={s.updated} intro={s.intro} sections={s.sections} />
+}
+
+export function LegalDoc({ title, updated, intro, sections }: { title: string; updated: string; intro: string; sections: Section[] }) {
+  return (
+    <div className="wrap py-[clamp(1.5rem,4vw,2.5rem)] max-w-[46rem] animate-[fadeUp_0.5s_ease_both]">
+      <h1 className="font-display text-[clamp(1.6rem,4vw,2.1rem)] text-ink mb-1">{title}</h1>
+      <p className="text-[0.85rem] text-ink-faint font-mono mb-5">{updated}</p>
+      <p className="text-[0.98rem] text-ink-soft leading-relaxed mb-6">{intro}</p>
+      <div className="flex flex-col gap-6">
+        {sections.map((sec, i) => (
+          <section key={i} className="flex flex-col gap-2">
+            <h2 className="font-display text-[1.2rem] text-ink">{sec.h}</h2>
+            {sec.p.map((para, j) => (
+              <p key={j} className="text-[0.95rem] text-ink-soft leading-relaxed">{para}</p>
+            ))}
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,93 @@
+import { useLocale } from '../i18n'
+import { useDocumentMeta } from '../lib/useDocumentMeta'
+import { LegalDoc } from './PrivacyPage'
+
+const STR = {
+  en: {
+    title: 'Terms of Use',
+    updated: 'Last updated: 6 July 2026',
+    intro:
+      'These simple terms cover your use of Built in Saudi (built-in-saudi.com) and its tools, including Book With Me.',
+    sections: [
+      {
+        h: 'The service',
+        p: [
+          'Built in Saudi is a free set of online tools, provided as-is with no warranties. We aim to keep it accurate and available but can’t guarantee it will be uninterrupted or error-free.',
+        ],
+      },
+      {
+        h: 'Acceptable use',
+        p: [
+          'Use the tools lawfully. Don’t use Book With Me to send spam, harass people, or misrepresent who you are. We may disable a scheduling link that is abused.',
+        ],
+      },
+      {
+        h: 'Bookings',
+        p: [
+          'A booking made through Book With Me is an arrangement between the host and the person booking. Built in Saudi provides the scheduling tool but is not a party to, and not responsible for, the meeting itself.',
+        ],
+      },
+      {
+        h: 'Liability',
+        p: [
+          'To the extent permitted by law, Built in Saudi is not liable for any indirect or consequential loss arising from use of the tools, including missed or double-booked meetings.',
+        ],
+      },
+      {
+        h: 'Changes',
+        p: ['We may update these terms or a tool at any time. Continued use means you accept the current version.'],
+      },
+      {
+        h: 'Contact',
+        p: ['Questions: hello@built-in-saudi.com.'],
+      },
+    ],
+  },
+  ar: {
+    title: 'شروط الاستخدام',
+    updated: 'آخر تحديث: ٦ يوليو ٢٠٢٦',
+    intro:
+      'تغطي هذه الشروط البسيطة استخدامك لـ«بُنِيَ في السعودية» (built-in-saudi.com) وأدواته، بما في ذلك «احجز معي».',
+    sections: [
+      {
+        h: 'الخدمة',
+        p: [
+          '«بُنِيَ في السعودية» مجموعة أدوات مجانية تُقدَّم كما هي دون ضمانات. نسعى لإبقائها دقيقة ومتاحة، لكن لا نضمن أن تكون دون انقطاع أو أخطاء.',
+        ],
+      },
+      {
+        h: 'الاستخدام المقبول',
+        p: [
+          'استخدم الأدوات بشكل قانوني. لا تستخدم «احجز معي» لإرسال رسائل مزعجة أو مضايقة الآخرين أو انتحال الهوية. قد نعطّل رابط حجز يُساء استخدامه.',
+        ],
+      },
+      {
+        h: 'الحجوزات',
+        p: [
+          'الحجز عبر «احجز معي» ترتيب بين المُضيف والشخص الحاجز. نوفّر أداة الجدولة فقط، ولسنا طرفًا في الاجتماع نفسه ولا مسؤولين عنه.',
+        ],
+      },
+      {
+        h: 'المسؤولية',
+        p: [
+          'بالقدر الذي يسمح به القانون، لا يتحمّل «بُنِيَ في السعودية» أي خسارة غير مباشرة أو تبعية ناتجة عن استخدام الأدوات، بما في ذلك الاجتماعات الفائتة أو المحجوزة مرتين.',
+        ],
+      },
+      {
+        h: 'التغييرات',
+        p: ['قد نحدّث هذه الشروط أو أي أداة في أي وقت. استمرارك في الاستخدام يعني قبول النسخة الحالية.'],
+      },
+      {
+        h: 'التواصل',
+        p: ['للأسئلة: hello@built-in-saudi.com.'],
+      },
+    ],
+  },
+}
+
+export function TermsPage() {
+  const { locale } = useLocale()
+  const s = STR[locale]
+  useDocumentMeta(locale, '/terms', s.title, s.intro.slice(0, 155))
+  return <LegalDoc title={s.title} updated={s.updated} intro={s.intro} sections={s.sections} />
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,8 @@ import { RootRedirect } from './components/RootRedirect'
 import { HomePage } from './pages/HomePage'
 import { ToolPage } from './pages/ToolPage'
 import { BookingPage } from './pages/BookingPage'
+import { PrivacyPage } from './pages/PrivacyPage'
+import { TermsPage } from './pages/TermsPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { ErrorPage } from './components/ErrorPage'
 
@@ -21,6 +23,8 @@ export const router = createBrowserRouter([
       // /book/<code> hits Layout with an invalid :lang and redirects to the
       // visitor's locale (/en|/ar), so booking links aren't language-locked.
       { path: 'book/:code', element: <BookingPage />, errorElement: <ErrorPage /> },
+      { path: 'privacy', element: <PrivacyPage />, errorElement: <ErrorPage /> },
+      { path: 'terms', element: <TermsPage />, errorElement: <ErrorPage /> },
       { path: '*', element: <NotFoundPage /> },
     ],
   },

--- a/src/tools/book-with-me/AvailabilityGrid.tsx
+++ b/src/tools/book-with-me/AvailabilityGrid.tsx
@@ -130,7 +130,7 @@ export function AvailabilityGrid({
                     data-testid={`cell-${day}-${row}`}
                     aria-label={`${days[day]} ${minutesToHHMM(rowToMinutes(row))}`}
                     className={[
-                      'h-4 cursor-crosshair border-[color:var(--line-soft)]',
+                      'h-7 cursor-crosshair border-[color:var(--line-soft)]',
                       day === 0 ? 'border-s' : '',
                       'border-e border-b',
                       isHour ? 'border-t border-t-[color:var(--line)]' : '',

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocale } from '../../i18n'
-import { CopyIcon } from '../../components/icons'
-import { Button, Input, Field, Stack, Seg, SegButton, Panel, Check } from '../../components/ui'
+import { CopyIcon, BellIcon } from '../../components/icons'
+import { Button, Input, Field, Stack, Seg, SegButton, Panel, Check, Pill, Sheet, SheetTitle, SheetActions } from '../../components/ui'
 import { AvailabilityGrid } from './AvailabilityGrid'
 import { connectGoogleUrl, saveSchedule } from '../../lib/bookingApi'
+import { subscribeDevice } from '../../lib/push'
 import {
   loadConfig,
   saveConfig,
@@ -42,76 +43,88 @@ function readSession(): Session | null {
 
 const STR = {
   en: {
-    intro: 'Set when you’re free, share one link, let people self-book. Your schedule is saved on this device.',
+    intro: 'Set when you’re free, share one link, let people self-book.',
     availability: 'Your weekly availability',
     tzNote: (tz: string) => `Times are in your current timezone — ${tz}. Availability maps to your Google Calendar in this zone; visitors see and book slots in their own timezone.`,
     meeting: 'Meeting settings',
     length: 'Length',
+    lengthHint: 'Each available hour is divided into sessions of this length (e.g. 30 min → two per hour; 45 min → one, with a gap).',
     min: 'min',
     gap: 'Gap between meetings',
     notice: 'Minimum notice',
     hours: 'hours',
     horizon: 'Bookable up to',
     days: 'days ahead',
-    title: 'Meeting title',
-    titlePh: 'Intro call',
-    location: 'Location / link',
-    locationPh: 'Google Meet, phone, address…',
-    share: 'Your booking link',
-    shareNote: 'Goes live once publishing is enabled. Anyone with the link can pick an open slot — no account needed.',
+    title: 'Meeting name',
+    titlePh: 'e.g. Intro call, Consultation',
+    titleHelp: 'What people are booking — shown on your booking page and used as the calendar event title.',
+    location: 'Where it happens',
+    locationPh: 'e.g. Google Meet link, phone number, address',
+    locationHelp: 'Optional. Added to the calendar invite so the booker knows where to go. Leave blank to sort out later.',
+    shareTitle: 'Share your booking page',
+    private: 'Private',
+    published: 'Published',
+    publishCta: 'Publish',
+    publishNote: 'Publish to activate your link — you’ll sign in with Google so we can check your calendar for conflicts and add booked meetings automatically.',
+    connectedAs: (who: string) => `Connected as ${who}`,
     copy: 'Copy link',
     copied: 'Copied!',
-    notify: 'Notify me when someone books',
-    push: 'Push to this device',
-    telegram: 'Telegram DM',
-    email: 'Email',
-    linkTg: 'Link my Telegram',
-    notifyNote: 'Push and Telegram activate after the backend deploy; email confirmations are on by default.',
-    soon: 'Availability & settings save on this device until you publish.',
-    publish: 'Publish & connect Google Calendar',
-    publishNote: 'Connect once to sign in, check your real calendar for conflicts, and auto-add booked meetings. Your link goes live immediately.',
-    connectedAs: (who: string) => `Connected as ${who}`,
-    published: 'Published',
+    previewLink: 'Preview',
     save: 'Save changes',
     saving: 'Saving…',
     saved: 'Saved ✓',
     saveErr: 'Couldn’t save — try again.',
+    alertsTitle: 'Booking alerts',
+    alertsNote: 'Get pinged the moment someone books. Your booker always receives an email confirmation.',
+    push: 'Push to this device',
+    telegram: 'Telegram DM',
+    email: 'Email me too',
+    linkTg: 'Link my Telegram',
+    pushDenied: 'Notifications are blocked in your browser settings.',
+    done: 'Done',
+    soon: 'Your schedule saves on this device until you publish.',
   },
   ar: {
-    intro: 'حدِّد أوقات فراغك، وشارك رابطًا واحدًا، ودَع الناس يحجزون بأنفسهم. جدولك محفوظ على هذا الجهاز.',
+    intro: 'حدِّد أوقات فراغك، وشارك رابطًا واحدًا، ودَع الناس يحجزون بأنفسهم.',
     availability: 'أوقات فراغك الأسبوعية',
     tzNote: (tz: string) => `الأوقات بتوقيتك الحالي — ${tz}. تُطابَق الأوقات مع تقويم جوجل بهذا التوقيت؛ ويرى الزوار ويحجزون بتوقيتهم الخاص.`,
     meeting: 'إعدادات الاجتماع',
     length: 'المدة',
+    lengthHint: 'تُقسَّم كل ساعة متاحة إلى جلسات بهذه المدة (مثلاً ٣٠ دقيقة ← جلستان في الساعة؛ ٤٥ دقيقة ← جلسة واحدة مع فاصل).',
     min: 'دقيقة',
     gap: 'فاصل بين الاجتماعات',
     notice: 'أقل مهلة للحجز',
     hours: 'ساعات',
     horizon: 'الحجز حتى',
     days: 'يومًا مقدمًا',
-    title: 'عنوان الاجتماع',
-    titlePh: 'مكالمة تعارف',
-    location: 'المكان / الرابط',
-    locationPh: 'Google Meet، هاتف، عنوان…',
-    share: 'رابط الحجز الخاص بك',
-    shareNote: 'يعمل بعد تفعيل النشر. أي شخص لديه الرابط يختار وقتًا متاحًا — دون حساب.',
+    title: 'اسم الاجتماع',
+    titlePh: 'مثال: مكالمة تعارف، استشارة',
+    titleHelp: 'ما الذي يحجزه الناس — يظهر في صفحة الحجز ويُستخدم عنوانًا لحدث التقويم.',
+    location: 'أين سيُعقد',
+    locationPh: 'مثال: رابط Google Meet، رقم هاتف، عنوان',
+    locationHelp: 'اختياري. يُضاف إلى دعوة التقويم ليعرف الحاجز أين يذهب. اتركه فارغًا لتحديده لاحقًا.',
+    shareTitle: 'شارك صفحة الحجز',
+    private: 'خاص',
+    published: 'منشور',
+    publishCta: 'انشر',
+    publishNote: 'انشر لتفعيل رابطك — ستسجّل الدخول بجوجل لنتحقق من تعارضات تقويمك ونضيف الاجتماعات المحجوزة تلقائيًا.',
+    connectedAs: (who: string) => `متصل باسم ${who}`,
     copy: 'نسخ الرابط',
     copied: 'تم النسخ!',
-    notify: 'نبّهني عند الحجز',
-    push: 'إشعار لهذا الجهاز',
-    telegram: 'رسالة تيليجرام',
-    email: 'بريد إلكتروني',
-    linkTg: 'اربط تيليجرام',
-    notifyNote: 'الإشعارات وتيليجرام تُفعَّل بعد نشر الخادم؛ تأكيدات البريد مفعّلة افتراضيًا.',
-    soon: 'تُحفظ الأوقات والإعدادات على هذا الجهاز حتى تنشرها.',
-    publish: 'انشر واربط تقويم جوجل',
-    publishNote: 'اربط مرة واحدة لتسجيل الدخول، والتحقق من تعارضات تقويمك الحقيقي، وإضافة الاجتماعات المحجوزة تلقائيًا. يعمل رابطك فورًا.',
-    connectedAs: (who: string) => `متصل باسم ${who}`,
-    published: 'منشور',
+    previewLink: 'معاينة',
     save: 'حفظ التغييرات',
     saving: 'جارٍ الحفظ…',
     saved: 'تم الحفظ ✓',
     saveErr: 'تعذّر الحفظ — حاول مرة أخرى.',
+    alertsTitle: 'تنبيهات الحجز',
+    alertsNote: 'تصلك تنبيهات لحظة الحجز. ويستلم الحاجز دائمًا تأكيدًا بالبريد.',
+    push: 'إشعار لهذا الجهاز',
+    telegram: 'رسالة تيليجرام',
+    email: 'أرسل لي بريدًا أيضًا',
+    linkTg: 'اربط تيليجرام',
+    pushDenied: 'الإشعارات محظورة في إعدادات متصفحك.',
+    done: 'تم',
+    soon: 'يُحفظ جدولك على هذا الجهاز حتى تنشره.',
   },
 }
 
@@ -136,6 +149,8 @@ export default function BookWithMeTool() {
   const [copied, setCopied] = useState(false)
   const [session, setSession] = useState<Session | null>(null)
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [alertsOpen, setAlertsOpen] = useState(false)
+  const [pushDenied, setPushDenied] = useState(false)
 
   // On return from the Google OAuth callback the dashboard URL carries
   // #hsid=<session>&code=<hostCode>. Capture it, then clear the hash.
@@ -186,12 +201,39 @@ export default function BookWithMeTool() {
         meeting: cfg.meeting,
         availability: cfg.availability,
         notify: cfg.notify,
+        pushSub: cfg.pushSub,
       })
       setSaveState('saved')
       setTimeout(() => setSaveState('idle'), 2000)
     } catch {
       setSaveState('error')
     }
+  }
+
+  async function togglePush(on: boolean) {
+    if (!on) {
+      setCfg((c) => ({ ...c, notify: { ...c.notify, push: false } }))
+      return
+    }
+    const sub = await subscribeDevice()
+    if (!sub) {
+      setPushDenied(true)
+      return
+    }
+    setPushDenied(false)
+    const pushSub = sub.toJSON()
+    setCfg((c) => ({ ...c, notify: { ...c.notify, push: true }, pushSub }))
+    if (session) {
+      saveSchedule({ hsid: session.hsid, code: cfg.code, notify: { ...cfg.notify, push: true }, pushSub }).catch(() => {})
+    }
+  }
+
+  function setChannel(key: 'telegram' | 'email', on: boolean) {
+    setCfg((c) => ({ ...c, notify: { ...c.notify, [key]: on } }))
+  }
+
+  function openPreview() {
+    window.open(`/${locale}/book/${cfg.code}?preview=1`, '_blank', 'noopener')
   }
 
   async function copyLink() {
@@ -208,34 +250,7 @@ export default function BookWithMeTool() {
     <Stack data-testid="book-with-me">
       <p className="text-[0.95rem] text-ink-soft">{s.intro}</p>
 
-      {/* Publish / connect Google */}
-      <Panel>
-        {session ? (
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex flex-col gap-0.5">
-              <span className="inline-flex items-center gap-2 text-[0.9rem] font-semibold text-green-700">
-                <span className="size-2 rounded-full bg-green-600" /> {s.published}
-              </span>
-              <span className="text-[0.82rem] text-ink-faint">{s.connectedAs(session.email || session.name || '')}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              {saveState === 'error' && <span className="text-[0.82rem] text-gold-500">{s.saveErr}</span>}
-              <Button variant="primary" onClick={publish} disabled={saveState === 'saving'} data-testid="save-schedule">
-                {saveState === 'saving' ? s.saving : saveState === 'saved' ? s.saved : s.save}
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <Button variant="primary" className="self-start" onClick={publish} data-testid="connect-google">
-              {s.publish}
-            </Button>
-            <p className="text-[0.82rem] text-ink-faint">{s.publishNote}</p>
-          </div>
-        )}
-      </Panel>
-
-      {/* Availability painter — the centerpiece */}
+      {/* 1 · Availability painter — the centerpiece */}
       <Panel>
         <div className="flex flex-col gap-1">
           <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.availability}</span>
@@ -244,7 +259,7 @@ export default function BookWithMeTool() {
         <AvailabilityGrid grid={grid} onChange={updateGrid} locale={locale} />
       </Panel>
 
-      {/* Meeting settings */}
+      {/* 2 · Meeting settings */}
       <Panel>
         <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.meeting}</span>
 
@@ -274,6 +289,7 @@ export default function BookWithMeTool() {
               onChange={(e) => setMeeting('minutes', Math.max(5, Number(e.target.value) || 5))}
             />
           </div>
+          <span className="text-[0.78rem] text-ink-faint">{s.lengthHint}</span>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -294,65 +310,106 @@ export default function BookWithMeTool() {
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <Field label={s.title}>
+            <span className="text-[0.78rem] text-ink-faint">{s.titleHelp}</span>
             <Input value={cfg.meeting.title} placeholder={s.titlePh}
               onChange={(e) => setMeeting('title', e.target.value)} />
           </Field>
           <Field label={s.location}>
+            <span className="text-[0.78rem] text-ink-faint">{s.locationHelp}</span>
             <Input value={cfg.meeting.location} placeholder={s.locationPh}
               onChange={(e) => setMeeting('location', e.target.value)} />
           </Field>
         </div>
       </Panel>
 
-      {/* Share link */}
+      {/* 3 · Publish & share — after the schedule, Google-Docs style */}
       <Panel>
-        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.share}</span>
-        <div className="flex flex-wrap gap-2">
-          <Input className="font-mono grow min-w-0 text-[0.85rem]" readOnly value={link}
-            data-testid="booking-link" onFocus={(e) => e.currentTarget.select()} />
-          <Button variant="primary" onClick={copyLink} data-testid="copy-link">
-            <CopyIcon /> {copied ? s.copied : s.copy}
-          </Button>
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.shareTitle}</span>
+          <span
+            data-testid="publish-status"
+            className={`inline-flex items-center gap-1.5 text-[0.78rem] font-semibold px-2.5 py-1 rounded-full ${
+              session
+                ? 'bg-[color-mix(in_srgb,var(--green-400)_18%,transparent)] text-green-700'
+                : 'bg-[color-mix(in_srgb,var(--sand-100)_60%,transparent)] text-ink-faint'
+            }`}
+          >
+            {session && <span className="size-1.5 rounded-full bg-green-600" />}
+            {session ? s.published : s.private}
+          </span>
         </div>
-        <p className="text-[0.82rem] text-ink-faint">{s.shareNote}</p>
+
+        {session ? (
+          <>
+            <span className="text-[0.82rem] text-ink-faint">{s.connectedAs(session.email || session.name || '')}</span>
+            <div className="flex flex-wrap gap-2">
+              <Input className="font-mono grow min-w-0 text-[0.85rem]" readOnly value={link}
+                data-testid="booking-link" onFocus={(e) => e.currentTarget.select()} />
+              <Button variant="primary" onClick={copyLink} data-testid="copy-link">
+                <CopyIcon /> {copied ? s.copied : s.copy}
+              </Button>
+              <Button onClick={openPreview} data-testid="preview-link">{s.previewLink}</Button>
+            </div>
+            <div className="flex items-center gap-2">
+              {saveState === 'error' && <span className="text-[0.82rem] text-gold-500">{s.saveErr}</span>}
+              <Button variant="primary" onClick={publish} disabled={saveState === 'saving'} data-testid="save-schedule">
+                {saveState === 'saving' ? s.saving : saveState === 'saved' ? s.saved : s.save}
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-[0.82rem] text-ink-faint">{s.publishNote}</p>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="primary" onClick={publish} data-testid="connect-google">{s.publishCta}</Button>
+              <Button onClick={openPreview} data-testid="preview-link">{s.previewLink}</Button>
+            </div>
+          </>
+        )}
       </Panel>
 
-      {/* Notifications */}
-      <Panel>
-        <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.notify}</span>
-        <div className="flex flex-col gap-2">
-          <Check>
-            <input type="checkbox" checked={cfg.notify.push}
-              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, push: e.target.checked } }))} />
-            {s.push}
-          </Check>
-          <div className="flex flex-wrap items-center gap-3">
-            <Check>
-              <input type="checkbox" checked={cfg.notify.telegram}
-                onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, telegram: e.target.checked } }))} />
-              {s.telegram}
-            </Check>
-            {cfg.notify.telegram && (
-              <Button
-                href={`https://t.me/${TELEGRAM_BOT}?start=${cfg.code}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-testid="link-telegram"
-              >
-                {s.linkTg}
-              </Button>
-            )}
-          </div>
-          <Check>
-            <input type="checkbox" checked={cfg.notify.email}
-              onChange={(e) => setCfg((c) => ({ ...c, notify: { ...c.notify, email: e.target.checked } }))} />
-            {s.email}
-          </Check>
-        </div>
-        <p className="text-[0.82rem] text-ink-faint">{s.notifyNote}</p>
-      </Panel>
+      {/* 4 · Booking alerts — a pill that opens a settings sheet */}
+      <div className="flex items-center gap-2">
+        <Pill data-testid="alerts-pill" onClick={() => setAlertsOpen(true)}>
+          <BellIcon /> {s.alertsTitle}
+        </Pill>
+      </div>
 
       <p className="text-[0.82rem] text-ink-faint">{s.soon}</p>
+
+      {alertsOpen && (
+        <Sheet data-testid="alerts-sheet" onClose={() => setAlertsOpen(false)}>
+          <SheetTitle>{s.alertsTitle}</SheetTitle>
+          <Stack className="!gap-3">
+            <div className="flex flex-col gap-1">
+              <Check>
+                <input type="checkbox" checked={cfg.notify.push} onChange={(e) => togglePush(e.target.checked)} />
+                {s.push}
+              </Check>
+              {pushDenied && <span className="text-[0.8rem] text-gold-500 ms-7">{s.pushDenied}</span>}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Check>
+                <input type="checkbox" checked={cfg.notify.telegram} onChange={(e) => setChannel('telegram', e.target.checked)} />
+                {s.telegram}
+              </Check>
+              {cfg.notify.telegram && (
+                <Button href={`https://t.me/${TELEGRAM_BOT}?start=${cfg.code}`} target="_blank" rel="noopener noreferrer" data-testid="link-telegram">
+                  {s.linkTg}
+                </Button>
+              )}
+            </div>
+            <Check>
+              <input type="checkbox" checked={cfg.notify.email} onChange={(e) => setChannel('email', e.target.checked)} />
+              {s.email}
+            </Check>
+            <p className="text-[0.8rem] text-ink-faint">{s.alertsNote}</p>
+          </Stack>
+          <SheetActions>
+            <Button variant="primary" onClick={() => setAlertsOpen(false)}>{s.done}</Button>
+          </SheetActions>
+        </Sheet>
+      )}
     </Stack>
   )
 }

--- a/src/tools/book-with-me/lib.ts
+++ b/src/tools/book-with-me/lib.ts
@@ -25,14 +25,15 @@ export interface HostConfig {
   meeting: MeetingConfig
   availability: AvailWindow[]
   notify: { push: boolean; telegram: boolean; email: boolean }
+  pushSub?: unknown // this device's Web Push subscription, sent to the host record
 }
 
 // ---- Grid geometry ----------------------------------------------------------
 
 export const DAY_START_MIN = 6 * 60 // grid starts at 06:00
 export const DAY_END_MIN = 24 * 60 // …ends at 24:00
-export const SLOT_MIN = 30 // one grid row = 30 minutes
-export const ROWS = (DAY_END_MIN - DAY_START_MIN) / SLOT_MIN // 36
+export const SLOT_MIN = 60 // one grid row = one whole hour (availability is hourly)
+export const ROWS = (DAY_END_MIN - DAY_START_MIN) / SLOT_MIN // 18
 export const DAYS = 7
 
 export type Grid = boolean[][] // [day 0..6][row 0..ROWS-1]
@@ -109,21 +110,70 @@ export function enumerateDaySlots(
   busy: { start: number; end: number }[],
   now: number,
 ): Slot[] {
-  const step = (meeting.minutes + meeting.gapMinutes) * 60_000
   const len = meeting.minutes * 60_000
+  const step = (meeting.minutes + meeting.gapMinutes) * 60_000
   const earliest = now + meeting.minNoticeHours * 3_600_000
+  const HOUR = 3_600_000
   const slots: Slot[] = []
+  const add = (s: number) => {
+    const e = s + len
+    if (s < earliest) return
+    if (busy.some((b) => s < b.end && e > b.start)) return
+    slots.push({ startUtc: s, endUtc: e })
+  }
   for (const w of windows) {
     const winStart = dayMidnightUtc + hhmmToMinutes(w.start) * 60_000
     const winEnd = dayMidnightUtc + hhmmToMinutes(w.end) * 60_000
-    for (let s = winStart; s + len <= winEnd + 1; s += step) {
-      const e = s + len
-      if (s < earliest) continue
-      const clash = busy.some((b) => s < b.end && e > b.start)
-      if (!clash) slots.push({ startUtc: s, endUtc: e })
+    if (meeting.minutes > 60) {
+      // Long meetings span hour boundaries — step continuously across the window.
+      for (let s = winStart; s + len <= winEnd + 1; s += step) add(s)
+    } else {
+      // Sessions align to each whole hour; any leftover time is the gap.
+      for (let h = winStart; h < winEnd; h += HOUR)
+        for (let s = h; s + len <= h + HOUR + 1; s += step) add(s)
     }
   }
   return slots
+}
+
+/**
+ * Client-side slot preview from the host's own config, computed in the browser's
+ * local time (which is the host's tz). No backend, no busy-times — it's what the
+ * booking page would show for a host with an empty calendar. Used by ?preview=1.
+ */
+export function previewSlots(cfg: HostConfig, now: number = Date.now()): number[] {
+  const { meeting, availability } = cfg
+  const len = meeting.minutes
+  const step = meeting.minutes + meeting.gapMinutes
+  const earliest = now + meeting.minNoticeHours * 3_600_000
+  const horizonEnd = now + meeting.horizonDays * 86_400_000
+  const out: number[] = []
+  for (let d = 0; d <= meeting.horizonDays + 1; d++) {
+    const day = new Date(now + d * 86_400_000)
+    const weekday = day.getDay()
+    for (const w of availability) {
+      if (w.day !== weekday) continue
+      const [sh, sm] = w.start.split(':').map(Number)
+      const [eh, em] = w.end.split(':').map(Number)
+      const winStartMin = sh * 60 + sm
+      const winEndMin = eh * 60 + em
+      const addAt = (mins: number) => {
+        const dt = new Date(day)
+        dt.setHours(Math.floor(mins / 60), mins % 60, 0, 0)
+        const s = dt.getTime()
+        if (s < earliest || s > horizonEnd) return
+        out.push(s)
+      }
+      if (len > 60) {
+        for (let m = winStartMin; m + len <= winEndMin; m += step) addAt(m)
+      } else {
+        // Sessions align to each whole hour; leftover is the gap.
+        for (let h = winStartMin; h < winEndMin; h += 60)
+          for (let m = h; m + len <= h + 60; m += step) addAt(m)
+      }
+    }
+  }
+  return [...new Set(out)].sort((a, b) => a - b)
 }
 
 // ---- Defaults + persistence -------------------------------------------------

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { execSync } from 'node:child_process'
 import { en } from './src/i18n/en'
 import { ar } from './src/i18n/ar'
-import { siteMeta, liveToolSeo, type ToolSeo } from './src/i18n/seo'
+import { siteMeta, liveToolSeo, staticPageSeo, type ToolSeo } from './src/i18n/seo'
 
 const ORIGIN = 'https://built-in-saudi.com'
 const LOCALES = ['en', 'ar'] as const
@@ -113,6 +113,16 @@ function prerenderPlugin(): Plugin {
           page = injectContent(page, toolContent(locale, tool))
           write(`${locale}${sub}`, page)
         }
+
+        // Standalone pages (privacy, terms) — real 200 HTML with head + a
+        // crawlable content block; React renders the full page on mount.
+        for (const page of staticPageSeo) {
+          const ps = page[locale]
+          const sub = `/${page.id}`
+          let html = applyHead(shell, { locale, dir, title: `${ps.name}${suffix[locale]}`, desc: ps.description, canonical: `${ORIGIN}/${locale}${sub}`, sub })
+          html = injectContent(html, `<main><h1>${esc(ps.name)}</h1><p>${esc(ps.description)}</p></main>`)
+          write(`${locale}${sub}`, html)
+        }
       }
 
       // Root shell: English-default head + hreflang + language links (it redirects client-side).
@@ -120,7 +130,7 @@ function prerenderPlugin(): Plugin {
       root = injectContent(root, `<main><h1>${esc(siteMeta.en.title)}</h1><p><a href="/en">English</a> · <a href="/ar">العربية</a></p></main>`)
       writeFileSync(join(dist, 'index.html'), root)
 
-      console.log(`bis-prerender: localized static HTML for ${LOCALES.join(', ')} × ${liveToolSeo.length + 1} pages`)
+      console.log(`bis-prerender: localized static HTML for ${LOCALES.join(', ')} × ${liveToolSeo.length + staticPageSeo.length + 1} pages`)
     },
   }
 }


### PR DESCRIPTION
Addresses the dashboard feedback + unblocks OAuth verification.

- **Hourly availability grid** — paint whole hours; meeting length subdivides (30min→2/hr, 45min→1+gap). Per-hour alignment in preview + backend `openSlots`.
- **Publish/Share** moved *after* the schedule, Google-Docs style (Private/Published chip, share link, Preview).
- **Alerts pill → settings sheet** (push/Telegram/email), matching Prayer Times; device push subscribes on toggle, stored on the host record.
- Clearer meeting-name/location copy.
- **?preview=1** booking-page mode (local config, bookings disabled).
- **/privacy + /terms** bilingual prerendered pages + footer links (Google Limited-Use disclosure for verification).

Typecheck + build (37 prerendered pages) + node --check green. Per-hour slot math unit-sanity-checked.