### PR TITLE
Add CV Generator tool

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           # Prayer-alert vars + Book With Me vars (Google OAuth / Resend / Telegram).
           # GOOGLE_OAUTH_CLIENT_ID is public (repo variable); the rest are secrets.
-          ENVV: VAPID_PUBLIC=${{ secrets.VAPID_PUBLIC }},VAPID_PRIVATE=${{ secrets.VAPID_PRIVATE }},SENDER_SECRET=${{ secrets.SENDER_SECRET }},GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }},GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }},RESEND_API_KEY=${{ secrets.RESEND_API_KEY }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
+          ENVV: VAPID_PUBLIC=${{ secrets.VAPID_PUBLIC }},VAPID_PRIVATE=${{ secrets.VAPID_PRIVATE }},SENDER_SECRET=${{ secrets.SENDER_SECRET }},GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }},GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }},RESEND_API_KEY=${{ secrets.RESEND_API_KEY }},TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }},OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
         run: |
           set -e
           common=(--gen2 --runtime=nodejs20 --region=us-central1 \
@@ -61,3 +61,5 @@ jobs:
           gcloud functions deploy get-availability        "${common[@]}" --entry-point=getAvailability
           gcloud functions deploy book                    "${common[@]}" --entry-point=book
           gcloud functions deploy telegram-webhook        "${common[@]}" --entry-point=telegramWebhook
+          # CV Generator
+          gcloud functions deploy cv-generate             "${common[@]}" --entry-point=cvGenerate

--- a/functions/cv.js
+++ b/functions/cv.js
@@ -1,0 +1,161 @@
+// CV Generator backend — verifies a Google sign-in, rate-limits per user, and
+// asks OpenAI to regenerate the CV as strict JSON following the signal-not-noise
+// guidelines. Text-in, JSON-out; the browser renders + exports it. No new deps
+// (OpenAI + Google tokeninfo over fetch). Registered via index.js.
+
+import { http } from '@google-cloud/functions-framework'
+import firestore from '@google-cloud/firestore'
+
+const { Firestore } = firestore
+const db = new Firestore()
+const USAGE = 'cvUsage'
+
+const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID || ''
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || ''
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
+const SITE = 'https://built-in-saudi.com'
+const DAILY_LIMIT = 15 // generations per signed-in user per day
+
+function cors(req, res) {
+  const origin = (req.headers && req.headers.origin) || ''
+  const ok = /^https:\/\/([a-z0-9-]+\.)?built-in-saudi\.com$/.test(origin)
+  res.set('Access-Control-Allow-Origin', ok ? origin : SITE)
+  res.set('Vary', 'Origin')
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.set('Access-Control-Allow-Headers', 'Content-Type')
+}
+
+// Verify a Google Identity Services ID token (client-side sign-in). Returns the
+// { sub, email } or null. Uses Google's tokeninfo endpoint — fine at this scale.
+async function verifyGoogle(idToken) {
+  if (!idToken) return null
+  try {
+    const r = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(idToken)}`)
+    if (!r.ok) return null
+    const p = await r.json()
+    if (p.aud !== CLIENT_ID) return null
+    if (p.exp && Date.now() / 1000 > Number(p.exp)) return null
+    return { sub: p.sub, email: p.email }
+  } catch {
+    return null
+  }
+}
+
+const SYSTEM_PROMPT = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON.
+
+The purpose of a CV is NOT to get the job — it is to get the INTERVIEW. A recruiter spends ~10 seconds. Keep only SIGNAL, remove all NOISE.
+
+Rules (apply strictly):
+- Regenerate everything. Do not copy verbatim; tighten and sharpen.
+- Write the SUMMARY and SKILLS from the WHOLE document, not just any existing summary/skills section. The summary is 2–3 sentences, punchy, and MUST mention total years of experience.
+- In "summary" and in experience/project text, wrap the most important keywords in **double asterisks** so they render bold. Bold sparingly — only genuine signal (technologies, scale, notable employers, impact).
+- Dates: YEAR ONLY, never months. Ongoing roles use "Present" as endYear.
+- Location: country and maybe city only — never a street address. If every role shares the same location, put it once in contact.location and OMIT it from each experience item.
+- Links: use a short label ("GitHub", "LinkedIn", "Portfolio") with its URL — never the raw URL as the label.
+- Phone/email: raw values, no "Phone:" / "Email:" labels.
+- REMOVE entirely: photos, references, GPA, university coursework/curriculum, exact addresses, objective-statement fluff, and any irrelevant experience (e.g. unrelated retail/food jobs for an IT professional).
+- Prefer strong action-verb bullets with measurable impact. Summarise anything verbose.
+- Education: degree, institution, year only. No scores.
+- Keep it truthful — never invent employers, dates, or achievements not supported by the source text.
+
+Return ONLY JSON with exactly this shape (omit a section by giving an empty array; omit optional strings by leaving them empty):
+{
+  "name": string,
+  "role": string,                       // headline title
+  "available": string,                  // optional, e.g. "Open to relocation (UAE / KSA)"
+  "contact": { "location": string, "phone": string, "email": string, "links": [{ "label": string, "url": string }] },
+  "summary": string,                    // with **bold** keywords, mentions years of experience
+  "skills": [{ "category": string, "items": string }],
+  "experience": [{ "role": string, "company": string, "location": string, "startYear": string, "endYear": string, "bullets": [string] }],
+  "projects": [{ "name": string, "description": string }],
+  "talks": [{ "title": string, "detail": string, "year": string }],
+  "certifications": [{ "title": string, "detail": string, "year": string }],
+  "publications": [{ "title": string, "detail": string, "year": string }],
+  "education": [{ "degree": string, "institution": string, "year": string }],
+  "languages": [{ "name": string, "level": string }]
+}`
+
+function normalize(cv) {
+  const arr = (x) => (Array.isArray(x) ? x : [])
+  const str = (x) => (typeof x === 'string' ? x : '')
+  return {
+    name: str(cv.name),
+    role: str(cv.role),
+    available: str(cv.available),
+    contact: {
+      location: str(cv.contact && cv.contact.location),
+      phone: str(cv.contact && cv.contact.phone),
+      email: str(cv.contact && cv.contact.email),
+      links: arr(cv.contact && cv.contact.links).map((l) => ({ label: str(l.label), url: str(l.url) })).filter((l) => l.label && l.url),
+    },
+    summary: str(cv.summary),
+    skills: arr(cv.skills).map((g) => ({ category: str(g.category), items: str(g.items) })).filter((g) => g.category && g.items),
+    experience: arr(cv.experience).map((j) => ({
+      role: str(j.role), company: str(j.company), location: str(j.location),
+      startYear: str(j.startYear), endYear: str(j.endYear), bullets: arr(j.bullets).map(str).filter(Boolean),
+    })).filter((j) => j.role || j.company),
+    projects: arr(cv.projects).map((p) => ({ name: str(p.name), description: str(p.description) })).filter((p) => p.name),
+    talks: arr(cv.talks).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
+    certifications: arr(cv.certifications).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
+    publications: arr(cv.publications).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
+    education: arr(cv.education).map((e) => ({ degree: str(e.degree), institution: str(e.institution), year: str(e.year) })).filter((e) => e.degree),
+    languages: arr(cv.languages).map((l) => ({ name: str(l.name), level: str(l.level) })).filter((l) => l.name),
+  }
+}
+
+// POST { idToken, text } → { ok, cv }
+http('cvGenerate', async (req, res) => {
+  cors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).send('')
+  if (req.method !== 'POST') return res.status(405).send('POST only')
+  try {
+    const { idToken, text } = req.body || {}
+    const user = await verifyGoogle(idToken)
+    if (!user) return res.status(401).json({ error: 'sign in with Google first' })
+    if (!text || String(text).trim().length < 60) return res.status(400).json({ error: 'CV text too short' })
+
+    // Per-user daily rate limit.
+    const today = new Date().toISOString().slice(0, 10)
+    const ref = db.collection(USAGE).doc(user.sub)
+    const over = await db.runTransaction(async (t) => {
+      const snap = await t.get(ref)
+      const d = snap.exists ? snap.data() : {}
+      const count = d.day === today ? Number(d.count || 0) : 0
+      if (count >= DAILY_LIMIT) return true
+      t.set(ref, { day: today, count: count + 1, email: user.email, updatedAt: new Date() }, { merge: true })
+      return false
+    })
+    if (over) return res.status(429).json({ error: 'daily limit reached — try again tomorrow' })
+
+    if (!OPENAI_API_KEY) return res.status(500).json({ error: 'OPENAI_API_KEY not configured' })
+    const ai = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        temperature: 0.3,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}` },
+        ],
+      }),
+    })
+    if (!ai.ok) {
+      const body = await ai.text()
+      console.error('openai error', ai.status, body.slice(0, 300))
+      return res.status(502).json({ error: `AI service error (${ai.status})` })
+    }
+    const data = await ai.json()
+    const content = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
+    let cv
+    try {
+      cv = normalize(JSON.parse(content))
+    } catch (e) {
+      return res.status(502).json({ error: 'AI returned malformed JSON' })
+    }
+    res.json({ ok: true, cv })
+  } catch (e) {
+    res.status(500).json({ error: String((e && e.message) || e) })
+  }
+})

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,6 +6,8 @@ import * as adhan from 'adhan'
 // getAvailability, book, telegramWebhook). Importing here registers their
 // http() handlers; VAPID is configured below and shared.
 import './booking.js'
+// CV Generator endpoint (cvGenerate).
+import './cv.js'
 
 const { Firestore } = firestore
 const db = new Firestore()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "adhan": "^4.4.4",
+        "mammoth": "^1.12.0",
         "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^6.1.200",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -749,6 +751,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
+      "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-x64": "1.0.2",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.2",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.2",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.2",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz",
+      "integrity": "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {
@@ -1545,6 +1797,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/adhan": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/adhan/-/adhan-4.4.4.tgz",
@@ -1575,6 +1836,35 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
@@ -1587,6 +1877,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
@@ -1689,6 +1985,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1738,6 +2040,21 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.384",
@@ -1869,6 +2186,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1877,6 +2206,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -1918,6 +2253,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -2205,6 +2561,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2223,6 +2590,30 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {
@@ -2260,6 +2651,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -2312,6 +2709,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
@@ -2322,6 +2728,18 @@
         "@pdf-lib/upng": "^1.0.1",
         "pako": "^1.0.11",
         "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.1.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
+      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -2416,6 +2834,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -2502,6 +2926,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2562,6 +3001,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2587,6 +3032,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2595,6 +3046,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -2664,6 +3130,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -2701,6 +3173,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -2781,6 +3259,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "adhan": "^4.4.4",
+    "mammoth": "^1.12.0",
     "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^6.1.200",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -180,6 +180,17 @@ export function CalendarIcon({ className }: P) {
   )
 }
 
+export function CvIcon({ className }: P) {
+  return (
+    <svg {...base} className={className} aria-hidden="true">
+      <path d="M6 3h7l5 5v13a0 0 0 0 1 0 0H6a0 0 0 0 1 0 0V3Z" />
+      <path d="M13 3v5h5" />
+      <path d="M8.5 12.5h4M8.5 15.5h7M8.5 18.5h5" />
+      <path d="M16.5 4.2l.5 1.3 1.3.5-1.3.5-.5 1.3-.5-1.3-1.3-.5 1.3-.5.5-1.3Z" />
+    </svg>
+  )
+}
+
 export function CalendarCheckIcon({ className }: P) {
   return (
     <svg {...base} className={className} aria-hidden="true">

--- a/src/i18n/seo.ts
+++ b/src/i18n/seo.ts
@@ -44,6 +44,11 @@ export const liveToolSeo: ToolSeo[] = [
     ar: { name: 'احجز معي', description: 'رابط جدولة مجاني بلا تسجيل — ارسم أوقات فراغك الأسبوعية، وحدِّد مدة الاجتماع بفواصل ومهل، وشارك رابطًا واحدًا. يحجز الناس وقتًا متاحًا دون تبادل رسائل، وتصلك إشعارات ورسالة تيليجرام وبريد عند الحجز.' },
   },
   {
+    id: 'cv-generator',
+    en: { name: 'CV Generator', description: 'Upload your CV and get it rewritten into a clean, ATS-ready résumé — signal only, no noise. Photos, colours, GPAs and references stripped; skills and a punchy summary synthesised from your whole history. Export PDF or Word.' },
+    ar: { name: 'منشئ السيرة الذاتية', description: 'ارفع سيرتك واحصل عليها معادةَ الكتابة في قالب نظيف متوافق مع أنظمة التتبّع — إشارة بلا ضجيج. تُزال الصور والألوان والمعدّلات والمراجع؛ وتُستخلص المهارات وملخّص موجز. صدّر PDF أو Word.' },
+  },
+  {
     id: 'color-tools',
     en: { name: 'Color Picker & Palettes', description: 'Pick a colour and read it as HEX/RGB/HSL, then generate complementary, analogous and triadic palettes plus a shades ramp — copy any swatch. In your browser.' },
     ar: { name: 'منتقي الألوان واللوحات', description: 'اختر لونًا واقرأه بصيغ HEX/RGB/HSL، ثم ولّد لوحات مكمّلة ومتجانسة وثلاثية وتدرّجات — وانسخ أي لون. داخل متصفحك.' },

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -1,0 +1,61 @@
+import type { Cv } from '../tools/cv-generator/schema'
+
+// Google Identity Services sign-in + the CV generation call. The client ID is
+// public (like the VAPID key in push.ts).
+export const GOOGLE_CLIENT_ID = '736023550280-71bb5sl89i1trt8p1obk8h35jrn6t7a3.apps.googleusercontent.com'
+const FN = 'https://us-central1-blitz-ksa.cloudfunctions.net'
+
+interface GisId {
+  initialize(cfg: { client_id: string; callback: (r: { credential: string }) => void }): void
+  renderButton(el: HTMLElement, opts: Record<string, unknown>): void
+  disableAutoSelect(): void
+}
+declare global {
+  interface Window {
+    google?: { accounts?: { id?: GisId } }
+  }
+}
+
+let gisPromise: Promise<GisId> | null = null
+
+/** Load the Google Identity Services script once. */
+export function loadGis(): Promise<GisId> {
+  if (gisPromise) return gisPromise
+  gisPromise = new Promise((resolve, reject) => {
+    const ready = () => {
+      const id = window.google?.accounts?.id
+      if (id) resolve(id)
+      else reject(new Error('GIS unavailable'))
+    }
+    if (window.google?.accounts?.id) return ready()
+    const s = document.createElement('script')
+    s.src = 'https://accounts.google.com/gsi/client'
+    s.async = true
+    s.defer = true
+    s.onload = ready
+    s.onerror = () => reject(new Error('Google sign-in failed to load'))
+    document.head.appendChild(s)
+  })
+  return gisPromise
+}
+
+/** Decode a JWT payload (unverified — display only). */
+export function decodeJwt(token: string): { email?: string; name?: string; picture?: string } {
+  try {
+    const b = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
+    return JSON.parse(atob(b.padEnd(Math.ceil(b.length / 4) * 4, '=')))
+  } catch {
+    return {}
+  }
+}
+
+export async function generateCv(idToken: string, text: string): Promise<Cv> {
+  const r = await fetch(`${FN}/cv-generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ idToken, text }),
+  })
+  const data = await r.json().catch(() => ({}))
+  if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)
+  return data.cv as Cv
+}

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState, type ChangeEvent } from 'react'
+import { useLocale } from '../../i18n'
+import { Button, Panel, Stack } from '../../components/ui'
+import { DownloadIcon } from '../../components/icons'
+import { loadGis, GOOGLE_CLIENT_ID, decodeJwt, generateCv } from '../../lib/cvApi'
+import { renderCvHtml, renderCvWordBlob } from './template'
+import { cvFilename, type Cv } from './schema'
+
+const STR = {
+  en: {
+    intro: 'Rebuild your CV for the 10-second recruiter scan — signal only, no noise. Upload your current CV; we rewrite it into a clean, ATS-ready template.',
+    why: 'The purpose of a CV is not to get the job — it’s to get the interview. We strip the noise (photos, colours, GPAs, references, exact address, month-level dates) and keep only what earns a second look.',
+    signin: 'Sign in with Google to continue',
+    signinNote: 'Sign-in keeps this free tool from being abused. We only read your name and email — nothing is posted anywhere.',
+    signedInAs: (e: string) => `Signed in as ${e}`,
+    upload: 'Upload your CV',
+    uploadHint: 'PDF, Word (.docx) or plain text. It’s read in your browser — only the extracted text is sent for rewriting.',
+    choose: 'Choose file',
+    extracting: 'Reading your CV…',
+    extracted: (n: number) => `Extracted ${n.toLocaleString()} characters.`,
+    tooShort: 'Couldn’t read enough text from that file. Try a text-based PDF or a .docx.',
+    extractErr: 'Couldn’t read that file. Try a PDF, .docx or .txt.',
+    generate: 'Generate my CV',
+    generating: 'Rewriting your CV…',
+    genErr: 'Generation failed. Please try again.',
+    result: 'Your rebuilt CV',
+    pdf: 'Save as PDF',
+    word: 'Download Word',
+    again: 'Regenerate',
+    newFile: 'Start over',
+    signinErr: 'Google sign-in couldn’t load. Disable blockers and retry.',
+  },
+  ar: {
+    intro: 'أعِد بناء سيرتك لمسح المجنِّد الذي يستغرق ١٠ ثوانٍ — إشارة فقط بلا ضجيج. ارفع سيرتك الحالية ونعيد كتابتها في قالب نظيف متوافق مع أنظمة التتبّع.',
+    why: 'هدف السيرة ليس الحصول على الوظيفة — بل الحصول على المقابلة. نزيل الضجيج (الصور والألوان والمعدّلات والمراجع والعنوان الدقيق وتواريخ الأشهر) ونُبقي ما يستحق نظرة ثانية.',
+    signin: 'سجّل الدخول بجوجل للمتابعة',
+    signinNote: 'تسجيل الدخول يمنع إساءة استخدام هذه الأداة المجانية. نقرأ اسمك وبريدك فقط، ولا يُنشر أي شيء.',
+    signedInAs: (e: string) => `مسجّل باسم ${e}`,
+    upload: 'ارفع سيرتك الذاتية',
+    uploadHint: 'PDF أو Word‏ (.docx) أو نص. تُقرأ داخل متصفحك — ويُرسَل النص المستخرج فقط لإعادة الكتابة.',
+    choose: 'اختر ملفًا',
+    extracting: 'جارٍ قراءة سيرتك…',
+    extracted: (n: number) => `استُخرج ${n.toLocaleString()} حرفًا.`,
+    tooShort: 'تعذّرت قراءة نص كافٍ من الملف. جرّب PDF نصيًا أو .docx.',
+    extractErr: 'تعذّرت قراءة الملف. جرّب PDF أو .docx أو .txt.',
+    generate: 'أنشئ سيرتي',
+    generating: 'جارٍ إعادة كتابة سيرتك…',
+    genErr: 'فشل الإنشاء. حاول مرة أخرى.',
+    result: 'سيرتك بعد إعادة البناء',
+    pdf: 'حفظ PDF',
+    word: 'تنزيل Word',
+    again: 'إعادة الإنشاء',
+    newFile: 'ابدأ من جديد',
+    signinErr: 'تعذّر تحميل تسجيل دخول جوجل. عطّل المانعات وأعد المحاولة.',
+  },
+}
+
+type Status = 'idle' | 'extracting' | 'ready' | 'generating' | 'done' | 'error'
+
+export default function CvGeneratorTool() {
+  const { locale } = useLocale()
+  const s = STR[locale]
+  const [idToken, setIdToken] = useState<string | null>(null)
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [fileName, setFileName] = useState('')
+  const [text, setText] = useState('')
+  const [cv, setCv] = useState<Cv | null>(null)
+  const [err, setErr] = useState('')
+  const btnRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadGis()
+      .then((id) => {
+        if (cancelled) return
+        id.initialize({
+          client_id: GOOGLE_CLIENT_ID,
+          callback: (r) => {
+            setIdToken(r.credential)
+            setEmail(decodeJwt(r.credential).email || '')
+          },
+        })
+        if (btnRef.current) id.renderButton(btnRef.current, { theme: 'filled_blue', size: 'large', text: 'signin_with', shape: 'pill' })
+      })
+      .catch(() => setErr(s.signinErr))
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function onFile(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0]
+    e.target.value = ''
+    if (!f) return
+    setFileName(f.name)
+    setErr('')
+    setCv(null)
+    setStatus('extracting')
+    try {
+      const { extractText } = await import('./extract')
+      const t = await extractText(f)
+      if (!t || t.length < 60) {
+        setErr(s.tooShort)
+        setStatus('idle')
+        return
+      }
+      setText(t)
+      setStatus('ready')
+    } catch {
+      setErr(s.extractErr)
+      setStatus('idle')
+    }
+  }
+
+  async function generate() {
+    if (!idToken || !text) return
+    setStatus('generating')
+    setErr('')
+    try {
+      const result = await generateCv(idToken, text)
+      setCv(result)
+      setStatus('done')
+    } catch (e) {
+      setErr((e as Error).message || s.genErr)
+      setStatus('ready')
+    }
+  }
+
+  function exportPdf() {
+    if (!cv) return
+    const w = window.open('', '_blank')
+    if (!w) return
+    w.document.write(renderCvHtml(cv))
+    w.document.title = cvFilename(cv)
+    w.document.close()
+    setTimeout(() => {
+      w.focus()
+      w.print()
+    }, 500)
+  }
+
+  function exportWord() {
+    if (!cv) return
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(renderCvWordBlob(cv))
+    a.download = `${cvFilename(cv)}.doc`
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000)
+  }
+
+  return (
+    <Stack data-testid="cv-generator">
+      <p className="text-[0.95rem] text-ink-soft">{s.intro}</p>
+
+      {!idToken ? (
+        <Panel>
+          <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.signin}</span>
+          <div ref={btnRef} className="[color-scheme:light]" data-testid="google-signin" />
+          <p className="text-[0.82rem] text-ink-faint">{s.signinNote}</p>
+          {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
+        </Panel>
+      ) : (
+        <>
+          <p className="text-[0.82rem] text-ink-faint">{s.signedInAs(email)}</p>
+
+          <Panel>
+            <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.upload}</span>
+            <p className="text-[0.82rem] text-ink-faint">{s.uploadHint}</p>
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="inline-flex">
+                <input type="file" accept=".pdf,.docx,.txt,.md,text/plain,application/pdf" className="sr-only" onChange={onFile} data-testid="cv-file" />
+                <span className="cursor-pointer inline-flex items-center gap-2 rounded-md border border-[color:var(--line)] bg-[var(--surface)] px-4 py-2 text-[0.9rem] font-semibold text-ink-soft hover:border-green-600 hover:text-green-700">
+                  {s.choose}
+                </span>
+              </label>
+              {fileName && <span className="text-[0.85rem] text-ink-faint font-mono truncate max-w-[16rem]">{fileName}</span>}
+            </div>
+            {status === 'extracting' && <p className="text-[0.85rem] text-ink-faint">{s.extracting}</p>}
+            {(status === 'ready' || status === 'generating' || status === 'done') && text && (
+              <p className="text-[0.85rem] text-green-700">{s.extracted(text.length)}</p>
+            )}
+            {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
+            {(status === 'ready' || status === 'generating' || status === 'done') && (
+              <Button variant="primary" className="self-start" onClick={generate} disabled={status === 'generating'} data-testid="cv-generate">
+                {status === 'generating' ? s.generating : status === 'done' ? s.again : s.generate}
+              </Button>
+            )}
+          </Panel>
+
+          {cv && status === 'done' && (
+            <Panel data-testid="cv-result">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.result}</span>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="primary" onClick={exportPdf} data-testid="cv-pdf"><DownloadIcon /> {s.pdf}</Button>
+                  <Button onClick={exportWord} data-testid="cv-word"><DownloadIcon /> {s.word}</Button>
+                </div>
+              </div>
+              <iframe
+                title={s.result}
+                className="w-full h-[75vh] rounded-md border border-[color:var(--line-soft)] bg-white"
+                srcDoc={renderCvHtml(cv)}
+              />
+              <p className="text-[0.8rem] text-ink-faint">{s.pdf}: {cvFilename(cv)}.pdf</p>
+            </Panel>
+          )}
+
+          <p className="text-[0.82rem] text-ink-faint">{s.why}</p>
+        </>
+      )}
+    </Stack>
+  )
+}

--- a/src/tools/cv-generator/extract.ts
+++ b/src/tools/cv-generator/extract.ts
@@ -1,0 +1,57 @@
+// Client-side text extraction — the CV file never leaves the browser; only the
+// extracted plain text is sent on for generation. PDF via pdf.js, DOCX via
+// mammoth, plus plain text. Both libs are heavy, so this module is imported
+// lazily from the tool.
+import * as pdfjs from 'pdfjs-dist'
+import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
+// @ts-expect-error - the browser build ships no types
+import mammoth from 'mammoth/mammoth.browser'
+
+pdfjs.GlobalWorkerOptions.workerSrc = workerUrl
+
+async function fromPdf(buf: ArrayBuffer): Promise<string> {
+  const doc = await pdfjs.getDocument({ data: buf }).promise
+  const pages: string[] = []
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i)
+    const content = await page.getTextContent()
+    // Rebuild lines from text items using their vertical position.
+    let line = ''
+    let lastY: number | null = null
+    const out: string[] = []
+    for (const item of content.items as { str: string; transform: number[] }[]) {
+      const y = item.transform[5]
+      if (lastY !== null && Math.abs(y - lastY) > 3) {
+        out.push(line.trimEnd())
+        line = ''
+      }
+      line += item.str + (item.str.endsWith(' ') ? '' : ' ')
+      lastY = y
+    }
+    if (line.trim()) out.push(line.trimEnd())
+    pages.push(out.join('\n'))
+  }
+  return pages.join('\n\n')
+}
+
+async function fromDocx(buf: ArrayBuffer): Promise<string> {
+  const res = await mammoth.extractRawText({ arrayBuffer: buf })
+  return String(res.value || '')
+}
+
+const MAX_CHARS = 30000 // plenty for a CV; guards the LLM call
+
+export async function extractText(file: File): Promise<string> {
+  const name = file.name.toLowerCase()
+  let text: string
+  if (name.endsWith('.pdf') || file.type === 'application/pdf') {
+    text = await fromPdf(await file.arrayBuffer())
+  } else if (name.endsWith('.docx')) {
+    text = await fromDocx(await file.arrayBuffer())
+  } else if (name.endsWith('.txt') || name.endsWith('.md') || file.type.startsWith('text/')) {
+    text = await file.text()
+  } else {
+    throw new Error('unsupported')
+  }
+  return text.replace(/\r/g, '').replace(/\n{3,}/g, '\n\n').trim().slice(0, MAX_CHARS)
+}

--- a/src/tools/cv-generator/meta.ts
+++ b/src/tools/cv-generator/meta.ts
@@ -1,0 +1,26 @@
+import { lazyTool } from '../../lib/lazyTool'
+import type { Tool } from '../types'
+import { CvIcon } from '../../components/icons'
+
+export const cvGeneratorTool: Tool = {
+  id: 'cv-generator',
+  name: 'CV Generator',
+  nameAr: 'منشئ السيرة الذاتية',
+  tagline: 'Rebuild your CV for the 10-second recruiter scan.',
+  description:
+    'Upload your existing CV and get it rewritten into a clean, ATS-ready résumé — signal only, no noise. Photos, colours, GPAs, references and month-level dates are stripped; skills and a punchy summary are synthesised from your whole history, key terms bolded. Export as PDF or Word. Sign-in with Google keeps it free and abuse-free.',
+  category: 'Business',
+  keywords: [
+    'cv', 'resume', 'résumé', 'cv generator', 'resume builder', 'ats', 'job', 'career', 'pdf', 'word',
+    'سيرة ذاتية', 'سيرة', 'ريزيومي', 'منشئ السيرة', 'وظيفة', 'توظيف',
+  ],
+  status: 'beta',
+  Icon: CvIcon,
+  component: lazyTool(() => import('./CvGeneratorTool')),
+  ar: {
+    name: 'منشئ السيرة الذاتية',
+    tagline: 'أعِد بناء سيرتك لمسح المجنِّد في ١٠ ثوانٍ.',
+    description:
+      'ارفع سيرتك الحالية واحصل عليها معادةَ الكتابة في قالب نظيف متوافق مع أنظمة التتبّع — إشارة فقط بلا ضجيج. تُزال الصور والألوان والمعدّلات والمراجع وتواريخ الأشهر؛ وتُستخلص المهارات وملخّص موجز من تاريخك كلّه مع إبراز الكلمات المهمة. صدّرها PDF أو Word. تسجيل الدخول بجوجل يبقيها مجانية وآمنة.',
+  },
+}

--- a/src/tools/cv-generator/schema.ts
+++ b/src/tools/cv-generator/schema.ts
@@ -1,0 +1,75 @@
+// The strict CV shape. The backend asks OpenAI to emit exactly this (via a
+// JSON schema), and template.ts renders it. Text fields may contain **markdown
+// bold** markers — the model marks the keywords worth emphasising, and the
+// renderer converts them to <b>. See docs: signal-not-noise guidelines.
+
+export interface CvLink {
+  label: string // "GitHub", "LinkedIn" — never the raw URL
+  url: string
+}
+
+export interface CvContact {
+  location?: string // country / city only, e.g. "Stockholm, Sweden"
+  phone?: string // raw number, no "Phone:" label
+  email?: string
+  links: CvLink[]
+}
+
+export interface CvSkillGroup {
+  category: string // "Languages & Core"
+  items: string // "Java, SQL, REST"
+}
+
+export interface CvExperience {
+  role: string
+  company: string
+  location?: string // omitted when same as the header location
+  startYear?: string // year only
+  endYear?: string // year only, or "Present"
+  bullets: string[] // each may contain **bold**
+}
+
+export interface CvProject {
+  name: string
+  description: string // may contain **bold**
+}
+
+export interface CvDated {
+  title: string
+  detail?: string // venue / issuer
+  year?: string
+}
+
+export interface CvEducation {
+  degree: string
+  institution?: string
+  year?: string // year only; no GPA, no coursework
+}
+
+export interface CvLanguage {
+  name: string
+  level?: string // e.g. "Native", "Fluent", "B2"
+}
+
+export interface Cv {
+  name: string
+  role: string // headline title, e.g. "Senior Java Backend Engineer"
+  available?: string // optional, e.g. "Open to Relocation (UAE / Saudi Arabia)"
+  contact: CvContact
+  summary: string // short, with **keywords** bolded; mentions years of experience
+  skills: CvSkillGroup[]
+  experience: CvExperience[]
+  projects: CvProject[]
+  talks: CvDated[]
+  certifications: CvDated[]
+  publications: CvDated[]
+  education: CvEducation[]
+  languages: CvLanguage[]
+}
+
+/** Build a filename like "Mirza Hussain CV 2026-07-06". */
+export function cvFilename(cv: Cv, date = new Date()): string {
+  const safe = (cv.name || 'Resume').replace(/[^\p{L}\p{N} .-]/gu, '').trim() || 'Resume'
+  const d = date.toISOString().slice(0, 10)
+  return `${safe} CV ${d}`
+}

--- a/src/tools/cv-generator/template.ts
+++ b/src/tools/cv-generator/template.ts
@@ -1,0 +1,165 @@
+import type { Cv } from './schema'
+
+// Renders a Cv into a full, standalone A4 résumé document (the template the user
+// supplied — sans-serif, no colour noise, print-optimised). The same HTML is
+// used for the on-screen preview and the print-to-PDF window.
+
+const esc = (s: string | undefined): string =>
+  (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+/** Escape, then turn **keyword** into <b>keyword</b> (the model marks emphasis). */
+const rich = (s: string | undefined): string =>
+  esc(s).replace(/\*\*([^*]+)\*\*/g, '<b>$1</b>')
+
+const CSS = `
+  :root{
+    --ink:#1b2230; --ink-soft:#28303e; --accent:#1e3a5f; --accent-2:#2f5482;
+    --muted:#5c6675; --line:#d7dbe2; --faint:#e6e9ee; --paper:#ffffff;
+    --backdrop:#e9ebef; --pad-x:16mm; --pad-y:13mm;
+    --sans:'IBM Plex Sans',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;padding:0;}
+  body{background:var(--backdrop);color:var(--ink);font-family:var(--sans);
+    line-height:1.45;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;padding:0;}
+  .resume{width:210mm;max-width:100%;margin:0 auto;background:var(--paper);
+    padding:var(--pad-y) var(--pad-x);}
+  .header{text-align:center;padding-bottom:11px;border-bottom:1.5px solid var(--accent);}
+  .name{margin:0;font-size:28px;font-weight:700;letter-spacing:0.035em;text-transform:uppercase;line-height:1.08;color:var(--accent);}
+  .contact{margin:9px 0 0;font-size:11.5px;color:var(--muted);}
+  /* Links: black, underlined text labels (never raw URLs). */
+  .contact a,.resume a{color:var(--ink);text-decoration:underline;}
+  .contact .sep{color:var(--line);margin:0 8px;}
+  .headline{margin:6px 0 0;font-size:12.5px;font-weight:600;line-height:1.4;color:var(--ink);}
+  .headline .role{color:var(--accent);}
+  .headline .sep{color:var(--line);margin:0 8px;font-weight:400;}
+  .section{margin-top:9px;}
+  .sec-head{display:flex;align-items:center;gap:12px;margin:0 0 6px;font-size:10.5px;font-weight:700;
+    text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);}
+  .sec-head::after{content:"";flex:1;height:1px;background:var(--line);}
+  .summary{margin:0;font-size:12.25px;line-height:1.4;color:var(--ink-soft);}
+  .summary b{font-weight:700;color:var(--ink);}
+  .skills{display:grid;grid-template-columns:max-content 1fr;gap:3px 16px;margin:0;font-size:12.25px;}
+  .skills dt{margin:0;padding-top:1.5px;font-size:10px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--accent-2);white-space:nowrap;}
+  .skills dd{margin:0;color:var(--ink);}
+  .job{margin-top:7px;}
+  .job:first-of-type{margin-top:0;}
+  .job-head{display:flex;justify-content:space-between;align-items:baseline;gap:12px;}
+  .job-meta{margin:0;font-size:12.5px;line-height:1.35;color:var(--ink);}
+  .job-meta .role{font-weight:700;color:var(--ink);}
+  .job-meta .co{color:var(--accent);font-weight:500;}
+  .job-meta .loc{color:var(--muted);}
+  .job-dates{font-size:11px;color:var(--muted);white-space:nowrap;text-align:right;flex-shrink:0;padding-top:0.5px;}
+  .job ul{margin:5px 0 0;padding:0;list-style:none;}
+  .job li{position:relative;padding-left:15px;margin-bottom:2.5px;font-size:12px;line-height:1.34;color:var(--ink-soft);}
+  .job li:last-child{margin-bottom:0;}
+  .job li::before{content:"";position:absolute;left:2px;top:0.5em;width:4px;height:4px;border-radius:1px;
+    background:var(--accent-2);-webkit-print-color-adjust:exact;print-color-adjust:exact;}
+  .job li b,.proj-line b{font-weight:700;color:var(--ink);}
+  .project{margin-top:5px;}
+  .project:first-of-type{margin-top:0;}
+  .proj-line{margin:0;font-size:12px;line-height:1.34;color:var(--ink-soft);}
+  .proj-name{font-weight:700;color:var(--ink);}
+  .row{display:flex;justify-content:space-between;align-items:baseline;gap:14px;margin-top:4px;}
+  .row:first-of-type{margin-top:0;}
+  .row .deg{font-size:12.5px;font-weight:600;color:var(--ink);}
+  .row .inst{font-size:12px;color:var(--muted);}
+  .row .year{font-size:11px;color:var(--muted);white-space:nowrap;}
+  .langs{margin:0;font-size:12.25px;color:var(--ink);}
+  @page{size:A4;margin:13mm 16mm;}
+  @media print{
+    html,body{background:#fff;}
+    .resume{width:auto;max-width:none;margin:0;padding:0;}
+    .job,.project,.row{break-inside:avoid;}
+    .sec-head{break-after:avoid;}
+    p,li{orphans:2;widows:2;}
+    *{-webkit-print-color-adjust:exact;print-color-adjust:exact;}
+  }
+`
+
+function contactLine(cv: Cv): string {
+  const parts: string[] = []
+  if (cv.contact.location) parts.push(esc(cv.contact.location))
+  if (cv.contact.phone) parts.push(`<a href="tel:${esc(cv.contact.phone)}">${esc(cv.contact.phone)}</a>`)
+  if (cv.contact.email) parts.push(`<a href="mailto:${esc(cv.contact.email)}">${esc(cv.contact.email)}</a>`)
+  for (const l of cv.contact.links || []) parts.push(`<a href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.label)}</a>`)
+  return parts.join('<span class="sep">|</span>')
+}
+
+function section(title: string, body: string): string {
+  if (!body.trim()) return ''
+  return `<section class="section"><h2 class="sec-head">${esc(title)}</h2>${body}</section>`
+}
+
+function dates(a?: string, b?: string): string {
+  if (a && b) return `${esc(a)} – ${esc(b)}`
+  return esc(a || b || '')
+}
+
+/** The résumé body (sections), signal-first. */
+function body(cv: Cv): string {
+  const summary = cv.summary ? `<p class="summary">${rich(cv.summary)}</p>` : ''
+
+  const skills = (cv.skills || []).length
+    ? `<dl class="skills">${cv.skills.map((g) => `<dt>${esc(g.category)}</dt><dd>${esc(g.items)}</dd>`).join('')}</dl>`
+    : ''
+
+  const experience = (cv.experience || [])
+    .map((j) => `<article class="job"><div class="job-head"><p class="job-meta">`
+      + `<span class="role">${esc(j.role)}</span>, <span class="co">${esc(j.company)}</span>`
+      + (j.location ? ` <span class="loc">(${esc(j.location)})</span>` : '')
+      + `</p><span class="job-dates">${dates(j.startYear, j.endYear)}</span></div>`
+      + `<ul>${(j.bullets || []).map((b) => `<li>${rich(b)}</li>`).join('')}</ul></article>`)
+    .join('')
+
+  const projects = (cv.projects || [])
+    .map((p) => `<div class="project"><p class="proj-line"><span class="proj-name">${esc(p.name)}</span> — ${rich(p.description)}</p></div>`)
+    .join('')
+
+  const dated = (items: Cv['certifications']) => items
+    .map((c) => `<div class="row"><span class="deg">${esc(c.title)}${c.detail ? ` <span class="inst">· ${esc(c.detail)}</span>` : ''}</span><span class="year">${esc(c.year)}</span></div>`)
+    .join('')
+
+  const education = (cv.education || [])
+    .map((e) => `<div class="row"><span class="deg">${esc(e.degree)}${e.institution ? ` <span class="inst">· ${esc(e.institution)}</span>` : ''}</span><span class="year">${esc(e.year)}</span></div>`)
+    .join('')
+
+  const languages = (cv.languages || []).length
+    ? `<p class="langs">${cv.languages.map((l) => esc(l.name) + (l.level ? ` (${esc(l.level)})` : '')).join(' · ')}</p>`
+    : ''
+
+  return [
+    section('Summary', summary),
+    section('Skills', skills),
+    section('Experience', experience),
+    section('Projects', projects),
+    section('Talks', dated(cv.talks || [])),
+    section('Certifications', dated(cv.certifications || [])),
+    section('Publications', dated(cv.publications || [])),
+    section('Education', education),
+    section('Languages', languages),
+  ].join('')
+}
+
+/** Full standalone HTML document for preview + print. */
+export function renderCvHtml(cv: Cv): string {
+  const header = `<header class="header">`
+    + `<h1 class="name">${esc(cv.name)}</h1>`
+    + `<p class="contact">${contactLine(cv)}</p>`
+    + `<p class="headline"><span class="role">${esc(cv.role)}</span>`
+    + (cv.available ? `<span class="sep">|</span><span>${esc(cv.available)}</span>` : '')
+    + `</p></header>`
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">`
+    + `<meta name="viewport" content="width=device-width, initial-scale=1">`
+    + `<title>${esc(cv.name)} — CV</title>`
+    + `<link rel="preconnect" href="https://fonts.googleapis.com">`
+    + `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
+    + `<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">`
+    + `<style>${CSS}</style></head><body><main class="resume">${header}${body(cv)}</main></body></html>`
+}
+
+/** A Word-openable .doc (HTML flavour) — editable, selectable text. Layout
+ *  fidelity in Word is approximate; the PDF is the pixel-perfect artefact. */
+export function renderCvWordBlob(cv: Cv): Blob {
+  return new Blob(['﻿' + renderCvHtml(cv)], { type: 'application/msword' })
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,7 @@ import { dateDiffTool } from './date-diff/meta'
 import { zipInspectorTool } from './zip-inspector/meta'
 import { metadataTool } from './metadata/meta'
 import { bookWithMeTool } from './book-with-me/meta'
+import { cvGeneratorTool } from './cv-generator/meta'
 
 /**
  * The tool catalog. Stable/beta tools render inside the app at /tools/:id.
@@ -42,6 +43,7 @@ import { bookWithMeTool } from './book-with-me/meta'
  */
 export const tools: Tool[] = [
   bookWithMeTool,
+  cvGeneratorTool,
   qrCodeTool,
   imageCompressorTool,
   imageFormatConverterTool,


### PR DESCRIPTION
Upload a CV → OpenAI rewrites it into a clean, ATS-ready résumé following the signal-not-noise guidelines → export PDF/Word.

- **Google sign-in** (GIS, lightweight) gates the LLM call; backend verifies the ID token + per-user daily rate limit.
- **Client-side extraction** (pdf.js / mammoth / txt), lazy-loaded so the heavy libs only load on file pick.
- **Backend** `functions/cv.js` → OpenAI (`gpt-4o`, JSON mode) with all the rules baked into the system prompt; normalises to a strict shape.
- **Render** into the supplied 'almost-perfect' template (parameterised), section order Summary→Skills→Experience→Projects→Talks→Certifications→Publications→Education→Languages; **bold keywords** the model marks; year-only dates; links as black underlined labels; GPA/references/photo/address stripped.
- **Export**: PDF via browser print (vector, ATS-readable, filename via title) + Word .doc.

Needs: `OPENAI_API_KEY` secret (placeholder set) + the OAuth client's **Authorized JavaScript origin** = https://built-in-saudi.com for GIS. Typecheck + build (38 prerendered pages) + node --check green.