### PR TITLE
CV Generator: rate limit + refine loop

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -63,3 +63,4 @@ jobs:
           gcloud functions deploy telegram-webhook        "${common[@]}" --entry-point=telegramWebhook
           # CV Generator
           gcloud functions deploy cv-generate             "${common[@]}" --entry-point=cvGenerate
+          gcloud functions deploy cv-refine               "${common[@]}" --entry-point=cvRefine

--- a/functions/cv.js
+++ b/functions/cv.js
@@ -1,7 +1,8 @@
 // CV Generator backend — verifies a Google sign-in, rate-limits per user, and
-// asks OpenAI to regenerate the CV as strict JSON following the signal-not-noise
-// guidelines. Text-in, JSON-out; the browser renders + exports it. No new deps
-// (OpenAI + Google tokeninfo over fetch). Registered via index.js.
+// asks OpenAI to (re)build the CV as strict JSON following the signal-not-noise
+// guidelines. Two flows: cvGenerate (fresh from an uploaded CV, 2 per 24h) and
+// cvRefine (up to 3 instruction-driven tweaks of the generated CV). Text-in,
+// JSON-out; the browser renders + exports. No new deps. Registered via index.js.
 
 import { http } from '@google-cloud/functions-framework'
 import firestore from '@google-cloud/firestore'
@@ -14,7 +15,10 @@ const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID || ''
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || ''
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
 const SITE = 'https://built-in-saudi.com'
-const DAILY_LIMIT = 15 // generations per signed-in user per day
+
+const UPLOAD_LIMIT = 2 // fresh generations per rolling 24h per user
+const REFINE_LIMIT = 3 // instruction tweaks per generated CV
+const WINDOW_MS = 24 * 60 * 60 * 1000
 
 function cors(req, res) {
   const origin = (req.headers && req.headers.origin) || ''
@@ -25,8 +29,7 @@ function cors(req, res) {
   res.set('Access-Control-Allow-Headers', 'Content-Type')
 }
 
-// Verify a Google Identity Services ID token (client-side sign-in). Returns the
-// { sub, email } or null. Uses Google's tokeninfo endpoint — fine at this scale.
+// Verify a Google Identity Services ID token (client-side sign-in).
 async function verifyGoogle(idToken) {
   if (!idToken) return null
   try {
@@ -41,30 +44,25 @@ async function verifyGoogle(idToken) {
   }
 }
 
-const SYSTEM_PROMPT = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON.
-
-The purpose of a CV is NOT to get the job — it is to get the INTERVIEW. A recruiter spends ~10 seconds. Keep only SIGNAL, remove all NOISE.
+const RULES = `The purpose of a CV is NOT to get the job — it is to get the INTERVIEW. A recruiter spends ~10 seconds. Keep only SIGNAL, remove all NOISE.
 
 Rules (apply strictly):
-- Regenerate everything. Do not copy verbatim; tighten and sharpen.
 - Write the SUMMARY and SKILLS from the WHOLE document, not just any existing summary/skills section. The summary is 2–3 sentences, punchy, and MUST mention total years of experience.
 - In "summary" and in experience/project text, wrap the most important keywords in **double asterisks** so they render bold. Bold sparingly — only genuine signal (technologies, scale, notable employers, impact).
 - Dates: YEAR ONLY, never months. Ongoing roles use "Present" as endYear.
 - Location: country and maybe city only — never a street address. If every role shares the same location, put it once in contact.location and OMIT it from each experience item.
-- Links: use a short label ("GitHub", "LinkedIn", "Portfolio") with its URL — never the raw URL as the label.
+- Links: a short label ("GitHub", "LinkedIn", "Portfolio") with its URL — never the raw URL as the label.
 - Phone/email: raw values, no "Phone:" / "Email:" labels.
 - REMOVE entirely: photos, references, GPA, university coursework/curriculum, exact addresses, objective-statement fluff, and any irrelevant experience (e.g. unrelated retail/food jobs for an IT professional).
 - Prefer strong action-verb bullets with measurable impact. Summarise anything verbose.
 - Education: degree, institution, year only. No scores.
-- Keep it truthful — never invent employers, dates, or achievements not supported by the source text.
+- Keep it truthful — never invent employers, dates, or achievements not supported by the source.
 
-Return ONLY JSON with exactly this shape (omit a section by giving an empty array; omit optional strings by leaving them empty):
+The JSON shape (omit a section with an empty array; omit optional strings by leaving them empty):
 {
-  "name": string,
-  "role": string,                       // headline title
-  "available": string,                  // optional, e.g. "Open to relocation (UAE / KSA)"
+  "name": string, "role": string, "available": string,
   "contact": { "location": string, "phone": string, "email": string, "links": [{ "label": string, "url": string }] },
-  "summary": string,                    // with **bold** keywords, mentions years of experience
+  "summary": string,
   "skills": [{ "category": string, "items": string }],
   "experience": [{ "role": string, "company": string, "location": string, "startYear": string, "endYear": string, "bullets": [string] }],
   "projects": [{ "name": string, "description": string }],
@@ -75,9 +73,14 @@ Return ONLY JSON with exactly this shape (omit a section by giving an empty arra
   "languages": [{ "name": string, "level": string }]
 }`
 
+const GENERATE_SYSTEM = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON. Regenerate everything — do not copy verbatim; tighten and sharpen.\n\n${RULES}\n\nReturn ONLY the JSON.`
+
+const REFINE_SYSTEM = `You are an elite technical résumé editor refining an ALREADY-structured CV (given as JSON). Apply the user's instruction, preserve everything the instruction does not touch, keep the EXACT same JSON shape, and keep obeying every rule below.\n\n${RULES}\n\nReturn ONLY the full updated JSON.`
+
 function normalize(cv) {
   const arr = (x) => (Array.isArray(x) ? x : [])
   const str = (x) => (typeof x === 'string' ? x : '')
+  const dated = (items) => arr(items).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title)
   return {
     name: str(cv.name),
     role: str(cv.role),
@@ -95,15 +98,53 @@ function normalize(cv) {
       startYear: str(j.startYear), endYear: str(j.endYear), bullets: arr(j.bullets).map(str).filter(Boolean),
     })).filter((j) => j.role || j.company),
     projects: arr(cv.projects).map((p) => ({ name: str(p.name), description: str(p.description) })).filter((p) => p.name),
-    talks: arr(cv.talks).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
-    certifications: arr(cv.certifications).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
-    publications: arr(cv.publications).map((t) => ({ title: str(t.title), detail: str(t.detail), year: str(t.year) })).filter((t) => t.title),
+    talks: dated(cv.talks),
+    certifications: dated(cv.certifications),
+    publications: dated(cv.publications),
     education: arr(cv.education).map((e) => ({ degree: str(e.degree), institution: str(e.institution), year: str(e.year) })).filter((e) => e.degree),
     languages: arr(cv.languages).map((l) => ({ name: str(l.name), level: str(l.level) })).filter((l) => l.name),
   }
 }
 
-// POST { idToken, text } → { ok, cv }
+async function callOpenAI(system, user) {
+  if (!OPENAI_API_KEY) {
+    const e = new Error('OPENAI_API_KEY not configured')
+    e.code = 500
+    throw e
+  }
+  const ai = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: OPENAI_MODEL,
+      temperature: 0.3,
+      response_format: { type: 'json_object' },
+      messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
+    }),
+  })
+  if (!ai.ok) {
+    const body = await ai.text()
+    console.error('openai error', ai.status, body.slice(0, 300))
+    const e = new Error(`AI service error (${ai.status})`)
+    e.code = 502
+    throw e
+  }
+  const data = await ai.json()
+  const content = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
+  try {
+    return normalize(JSON.parse(content))
+  } catch {
+    const e = new Error('AI returned malformed JSON')
+    e.code = 502
+    throw e
+  }
+}
+
+function fail(res, e) {
+  res.status(e && e.code ? e.code : 500).json({ error: String((e && e.message) || e) })
+}
+
+// POST { idToken, text } → { ok, cv, refinesLeft }. Fresh build; 2 per 24h.
 http('cvGenerate', async (req, res) => {
   cors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).send('')
@@ -114,48 +155,49 @@ http('cvGenerate', async (req, res) => {
     if (!user) return res.status(401).json({ error: 'sign in with Google first' })
     if (!text || String(text).trim().length < 60) return res.status(400).json({ error: 'CV text too short' })
 
-    // Per-user daily rate limit.
-    const today = new Date().toISOString().slice(0, 10)
     const ref = db.collection(USAGE).doc(user.sub)
-    const over = await db.runTransaction(async (t) => {
-      const snap = await t.get(ref)
-      const d = snap.exists ? snap.data() : {}
-      const count = d.day === today ? Number(d.count || 0) : 0
-      if (count >= DAILY_LIMIT) return true
-      t.set(ref, { day: today, count: count + 1, email: user.email, updatedAt: new Date() }, { merge: true })
-      return false
-    })
-    if (over) return res.status(429).json({ error: 'daily limit reached — try again tomorrow' })
+    const now = Date.now()
+    const d = (await ref.get()).data() || {}
+    const recent = (Array.isArray(d.uploads) ? d.uploads : []).filter((t) => now - Number(t) < WINDOW_MS)
+    if (recent.length >= UPLOAD_LIMIT) {
+      return res.status(429).json({ error: `Limit reached — you can generate ${UPLOAD_LIMIT} CVs per 24 hours. Try again later.` })
+    }
 
-    if (!OPENAI_API_KEY) return res.status(500).json({ error: 'OPENAI_API_KEY not configured' })
-    const ai = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: OPENAI_MODEL,
-        temperature: 0.3,
-        response_format: { type: 'json_object' },
-        messages: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}` },
-        ],
-      }),
-    })
-    if (!ai.ok) {
-      const body = await ai.text()
-      console.error('openai error', ai.status, body.slice(0, 300))
-      return res.status(502).json({ error: `AI service error (${ai.status})` })
-    }
-    const data = await ai.json()
-    const content = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
-    let cv
-    try {
-      cv = normalize(JSON.parse(content))
-    } catch (e) {
-      return res.status(502).json({ error: 'AI returned malformed JSON' })
-    }
-    res.json({ ok: true, cv })
+    const cv = await callOpenAI(GENERATE_SYSTEM, `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}`)
+    // Record the successful upload and reset the refine budget for this new CV.
+    await ref.set({ uploads: [...recent, now], refineCount: 0, email: user.email, updatedAt: new Date() }, { merge: true })
+    res.json({ ok: true, cv, refinesLeft: REFINE_LIMIT })
   } catch (e) {
-    res.status(500).json({ error: String((e && e.message) || e) })
+    fail(res, e)
+  }
+})
+
+// POST { idToken, cv, instruction } → { ok, cv, refinesLeft }. Up to 3 per CV.
+http('cvRefine', async (req, res) => {
+  cors(req, res)
+  if (req.method === 'OPTIONS') return res.status(204).send('')
+  if (req.method !== 'POST') return res.status(405).send('POST only')
+  try {
+    const { idToken, cv: current, instruction } = req.body || {}
+    const user = await verifyGoogle(idToken)
+    if (!user) return res.status(401).json({ error: 'sign in with Google first' })
+    if (!current || typeof current !== 'object') return res.status(400).json({ error: 'missing CV' })
+    if (!instruction || String(instruction).trim().length < 2) return res.status(400).json({ error: 'missing instruction' })
+
+    const ref = db.collection(USAGE).doc(user.sub)
+    const d = (await ref.get()).data() || {}
+    const used = Number(d.refineCount || 0)
+    if (used >= REFINE_LIMIT) {
+      return res.status(429).json({ error: `You’ve used all ${REFINE_LIMIT} tweaks for this CV. Upload again to start fresh.` })
+    }
+
+    const cv = await callOpenAI(
+      REFINE_SYSTEM,
+      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\nInstruction: ${String(instruction).slice(0, 1000)}`,
+    )
+    await ref.update({ refineCount: used + 1, updatedAt: new Date() })
+    res.json({ ok: true, cv, refinesLeft: REFINE_LIMIT - (used + 1) })
+  } catch (e) {
+    fail(res, e)
   }
 })

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -49,7 +49,12 @@ export function decodeJwt(token: string): { email?: string; name?: string; pictu
   }
 }
 
-export async function generateCv(idToken: string, text: string): Promise<Cv> {
+export interface CvResult {
+  cv: Cv
+  refinesLeft: number
+}
+
+export async function generateCv(idToken: string, text: string): Promise<CvResult> {
   const r = await fetch(`${FN}/cv-generate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -57,5 +62,17 @@ export async function generateCv(idToken: string, text: string): Promise<Cv> {
   })
   const data = await r.json().catch(() => ({}))
   if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)
-  return data.cv as Cv
+  return { cv: data.cv as Cv, refinesLeft: Number(data.refinesLeft ?? 0) }
+}
+
+/** Apply one instruction-driven tweak to an already-generated CV. */
+export async function refineCv(idToken: string, cv: Cv, instruction: string): Promise<CvResult> {
+  const r = await fetch(`${FN}/cv-refine`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ idToken, cv, instruction }),
+  })
+  const data = await r.json().catch(() => ({}))
+  if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)
+  return { cv: data.cv as Cv, refinesLeft: Number(data.refinesLeft ?? 0) }
 }

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { useLocale } from '../../i18n'
-import { Button, Panel, Stack } from '../../components/ui'
+import { Button, Panel, Stack, Input } from '../../components/ui'
 import { DownloadIcon } from '../../components/icons'
-import { loadGis, GOOGLE_CLIENT_ID, decodeJwt, generateCv } from '../../lib/cvApi'
+import { loadGis, GOOGLE_CLIENT_ID, decodeJwt, generateCv, refineCv } from '../../lib/cvApi'
 import { renderCvHtml, renderCvWordBlob } from './template'
 import { cvFilename, type Cv } from './schema'
 
@@ -29,6 +29,13 @@ const STR = {
     again: 'Regenerate',
     newFile: 'Start over',
     signinErr: 'Google sign-in couldn’t load. Disable blockers and retry.',
+    refineTitle: 'Fine-tune',
+    refinePh: 'e.g. Make the summary shorter · Emphasise leadership · Drop the oldest role',
+    apply: 'Apply',
+    applying: 'Applying…',
+    tweaksLeft: (n: number) => `${n} tweak${n === 1 ? '' : 's'} left`,
+    noTweaks: 'No tweaks left for this CV — upload again to start fresh.',
+    limitNote: '2 CVs per 24 hours · 3 tweaks each.',
   },
   ar: {
     intro: 'أعِد بناء سيرتك لمسح المجنِّد الذي يستغرق ١٠ ثوانٍ — إشارة فقط بلا ضجيج. ارفع سيرتك الحالية ونعيد كتابتها في قالب نظيف متوافق مع أنظمة التتبّع.',
@@ -52,6 +59,13 @@ const STR = {
     again: 'إعادة الإنشاء',
     newFile: 'ابدأ من جديد',
     signinErr: 'تعذّر تحميل تسجيل دخول جوجل. عطّل المانعات وأعد المحاولة.',
+    refineTitle: 'ضبط دقيق',
+    refinePh: 'مثال: اجعل الملخّص أقصر · أبرِز القيادة · احذف أقدم وظيفة',
+    apply: 'تطبيق',
+    applying: 'جارٍ التطبيق…',
+    tweaksLeft: (n: number) => `${n === 1 ? 'تعديل واحد متبقٍّ' : `${n} تعديلات متبقّية`}`,
+    noTweaks: 'لا تعديلات متبقّية لهذه السيرة — ارفع من جديد للبدء من الصفر.',
+    limitNote: 'سيرتان كل ٢٤ ساعة · ٣ تعديلات لكلٍّ.',
   },
 }
 
@@ -67,6 +81,9 @@ export default function CvGeneratorTool() {
   const [text, setText] = useState('')
   const [cv, setCv] = useState<Cv | null>(null)
   const [err, setErr] = useState('')
+  const [refinesLeft, setRefinesLeft] = useState(0)
+  const [instruction, setInstruction] = useState('')
+  const [refining, setRefining] = useState(false)
   const btnRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -119,12 +136,30 @@ export default function CvGeneratorTool() {
     setStatus('generating')
     setErr('')
     try {
-      const result = await generateCv(idToken, text)
+      const { cv: result, refinesLeft: left } = await generateCv(idToken, text)
       setCv(result)
+      setRefinesLeft(left)
+      setInstruction('')
       setStatus('done')
     } catch (e) {
       setErr((e as Error).message || s.genErr)
       setStatus('ready')
+    }
+  }
+
+  async function refine() {
+    if (!idToken || !cv || !instruction.trim() || refinesLeft <= 0 || refining) return
+    setRefining(true)
+    setErr('')
+    try {
+      const { cv: result, refinesLeft: left } = await refineCv(idToken, cv, instruction.trim())
+      setCv(result)
+      setRefinesLeft(left)
+      setInstruction('')
+    } catch (e) {
+      setErr((e as Error).message || s.genErr)
+    } finally {
+      setRefining(false)
     }
   }
 
@@ -169,7 +204,7 @@ export default function CvGeneratorTool() {
 
           <Panel>
             <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.upload}</span>
-            <p className="text-[0.82rem] text-ink-faint">{s.uploadHint}</p>
+            <p className="text-[0.82rem] text-ink-faint">{s.uploadHint} {s.limitNote}</p>
             <div className="flex flex-wrap items-center gap-3">
               <label className="inline-flex">
                 <input type="file" accept=".pdf,.docx,.txt,.md,text/plain,application/pdf" className="sr-only" onChange={onFile} data-testid="cv-file" />
@@ -200,6 +235,32 @@ export default function CvGeneratorTool() {
                   <Button onClick={exportWord} data-testid="cv-word"><DownloadIcon /> {s.word}</Button>
                 </div>
               </div>
+
+              {/* Fine-tune loop — up to 3 instruction tweaks, preview updates live */}
+              <div className="flex flex-col gap-2 border-t border-[color:var(--line-soft)] pt-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[0.82rem] font-semibold text-ink-soft">{s.refineTitle}</span>
+                  {refinesLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.tweaksLeft(refinesLeft)}</span>}
+                </div>
+                {refinesLeft > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    <Input
+                      className="grow min-w-0"
+                      value={instruction}
+                      placeholder={s.refinePh}
+                      data-testid="cv-instruction"
+                      onChange={(e) => setInstruction(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') refine() }}
+                    />
+                    <Button variant="primary" onClick={refine} disabled={refining || !instruction.trim()} data-testid="cv-refine">
+                      {refining ? s.applying : s.apply}
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-[0.82rem] text-ink-faint">{s.noTweaks}</p>
+                )}
+              </div>
+
               <iframe
                 title={s.result}
                 className="w-full h-[75vh] rounded-md border border-[color:var(--line-soft)] bg-white"

--- a/src/tools/cv-generator/template.ts
+++ b/src/tools/cv-generator/template.ts
@@ -33,7 +33,7 @@ const CSS = `
   .headline{margin:6px 0 0;font-size:12.5px;font-weight:600;line-height:1.4;color:var(--ink);}
   .headline .role{color:var(--accent);}
   .headline .sep{color:var(--line);margin:0 8px;font-weight:400;}
-  .section{margin-top:9px;}
+  .section{margin-top:16px;}
   .sec-head{display:flex;align-items:center;gap:12px;margin:0 0 6px;font-size:10.5px;font-weight:700;
     text-transform:uppercase;letter-spacing:0.15em;color:var(--accent);}
   .sec-head::after{content:"";flex:1;height:1px;background:var(--line);}


### PR DESCRIPTION
- **2 uploads / 24h** per user (rolling window).
- **cv-refine** endpoint — up to **3 instruction tweaks** per generated CV, budget resets on a new upload; preview updates live.
- Section `margin-top` 9px → 16px.

Typecheck + build + node --check green.