### PR TITLE
CV Generator: auto-fix + gap questions (agentic back-and-forth)

### DIFF
--- a/functions/cv.js
+++ b/functions/cv.js
@@ -58,7 +58,16 @@ Rules (apply strictly):
 - Education: degree, institution, year only. No scores.
 - Keep it truthful — never invent employers, dates, or achievements not supported by the source.
 
-The JSON shape (omit a section with an empty array; omit optional strings by leaving them empty):
+FIX SILENTLY (do not ask, just correct):
+- Spelling, grammar and typos.
+- Tone: make it professional, confident and concise. Rewrite anything unprofessional, casual, arrogant or over-the-top (e.g. "rockstar ninja", "single-handedly saved the company") into credible, specific, results-focused language.
+- Clarity: rewrite vague or confusing statements into clear ones where the meaning is reasonably inferable. Strip buzzword filler.
+
+ASK (only for MATERIAL gaps you cannot responsibly fix yourself):
+- Put up to 3 short, specific questions in "questions" when something important is missing or inconsistent and answering it would materially strengthen the CV. Examples: a role/seniority with no supporting evidence (e.g. "Developer, 3 years" but no technologies, projects or achievements listed); conflicting or impossible dates; a large unexplained employment gap; a claimed skill never evidenced.
+- Do NOT ask about trivial things, and never invent facts to fill a gap. Always still produce the best CV you can from what's given — questions are additive, never blocking. If nothing material is missing, return an empty array.
+
+The CV object shape (omit a section with an empty array; omit optional strings by leaving them empty):
 {
   "name": string, "role": string, "available": string,
   "contact": { "location": string, "phone": string, "email": string, "links": [{ "label": string, "url": string }] },
@@ -71,11 +80,13 @@ The JSON shape (omit a section with an empty array; omit optional strings by lea
   "publications": [{ "title": string, "detail": string, "year": string }],
   "education": [{ "degree": string, "institution": string, "year": string }],
   "languages": [{ "name": string, "level": string }]
-}`
+}
 
-const GENERATE_SYSTEM = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON. Regenerate everything — do not copy verbatim; tighten and sharpen.\n\n${RULES}\n\nReturn ONLY the JSON.`
+Return ONLY JSON of the form: { "cv": { …the CV object above… }, "questions": [ up to 3 short strings ] }`
 
-const REFINE_SYSTEM = `You are an elite technical résumé editor refining an ALREADY-structured CV (given as JSON). Apply the user's instruction, preserve everything the instruction does not touch, keep the EXACT same JSON shape, and keep obeying every rule below.\n\n${RULES}\n\nReturn ONLY the full updated JSON.`
+const GENERATE_SYSTEM = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON. Regenerate everything — do not copy verbatim; tighten, sharpen, and fix issues silently.\n\n${RULES}`
+
+const REFINE_SYSTEM = `You are an elite technical résumé editor in a short back-and-forth with the candidate. You are given the current CV as JSON plus their message — which is EITHER an answer to one of your earlier questions OR an instruction to change something. Incorporate it: if it answers a gap, weave the new information in and drop that question; if it's an instruction, apply it. Preserve everything untouched, keep the EXACT same CV shape, keep obeying every rule, keep fixing issues silently, and re-evaluate remaining questions.\n\n${RULES}`
 
 function normalize(cv) {
   const arr = (x) => (Array.isArray(x) ? x : [])
@@ -132,7 +143,13 @@ async function callOpenAI(system, user) {
   const data = await ai.json()
   const content = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
   try {
-    return normalize(JSON.parse(content))
+    const parsed = JSON.parse(content)
+    // Tolerate the model returning { cv, questions } or just the CV object.
+    const cvObj = parsed && parsed.cv && typeof parsed.cv === 'object' ? parsed.cv : parsed
+    const questions = Array.isArray(parsed && parsed.questions)
+      ? parsed.questions.map((q) => String(q).trim()).filter(Boolean).slice(0, 3)
+      : []
+    return { cv: normalize(cvObj), questions }
   } catch {
     const e = new Error('AI returned malformed JSON')
     e.code = 502
@@ -163,10 +180,10 @@ http('cvGenerate', async (req, res) => {
       return res.status(429).json({ error: `Limit reached — you can generate ${UPLOAD_LIMIT} CVs per 24 hours. Try again later.` })
     }
 
-    const cv = await callOpenAI(GENERATE_SYSTEM, `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}`)
+    const { cv, questions } = await callOpenAI(GENERATE_SYSTEM, `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}`)
     // Record the successful upload and reset the refine budget for this new CV.
     await ref.set({ uploads: [...recent, now], refineCount: 0, email: user.email, updatedAt: new Date() }, { merge: true })
-    res.json({ ok: true, cv, refinesLeft: REFINE_LIMIT })
+    res.json({ ok: true, cv, questions, refinesLeft: REFINE_LIMIT })
   } catch (e) {
     fail(res, e)
   }
@@ -191,12 +208,12 @@ http('cvRefine', async (req, res) => {
       return res.status(429).json({ error: `You’ve used all ${REFINE_LIMIT} tweaks for this CV. Upload again to start fresh.` })
     }
 
-    const cv = await callOpenAI(
+    const { cv, questions } = await callOpenAI(
       REFINE_SYSTEM,
-      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\nInstruction: ${String(instruction).slice(0, 1000)}`,
+      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\nCandidate's message: ${String(instruction).slice(0, 1000)}`,
     )
     await ref.update({ refineCount: used + 1, updatedAt: new Date() })
-    res.json({ ok: true, cv, refinesLeft: REFINE_LIMIT - (used + 1) })
+    res.json({ ok: true, cv, questions, refinesLeft: REFINE_LIMIT - (used + 1) })
   } catch (e) {
     fail(res, e)
   }

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -51,7 +51,16 @@ export function decodeJwt(token: string): { email?: string; name?: string; pictu
 
 export interface CvResult {
   cv: Cv
+  questions: string[]
   refinesLeft: number
+}
+
+function parseResult(data: { cv?: Cv; questions?: unknown; refinesLeft?: unknown }): CvResult {
+  return {
+    cv: data.cv as Cv,
+    questions: Array.isArray(data.questions) ? data.questions.map(String) : [],
+    refinesLeft: Number(data.refinesLeft ?? 0),
+  }
 }
 
 export async function generateCv(idToken: string, text: string): Promise<CvResult> {
@@ -62,10 +71,10 @@ export async function generateCv(idToken: string, text: string): Promise<CvResul
   })
   const data = await r.json().catch(() => ({}))
   if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)
-  return { cv: data.cv as Cv, refinesLeft: Number(data.refinesLeft ?? 0) }
+  return parseResult(data)
 }
 
-/** Apply one instruction-driven tweak to an already-generated CV. */
+/** Apply one message — an answer to an AI question, or an instruction. */
 export async function refineCv(idToken: string, cv: Cv, instruction: string): Promise<CvResult> {
   const r = await fetch(`${FN}/cv-refine`, {
     method: 'POST',
@@ -74,5 +83,5 @@ export async function refineCv(idToken: string, cv: Cv, instruction: string): Pr
   })
   const data = await r.json().catch(() => ({}))
   if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)
-  return { cv: data.cv as Cv, refinesLeft: Number(data.refinesLeft ?? 0) }
+  return parseResult(data)
 }

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -35,7 +35,9 @@ const STR = {
     applying: 'Applying…',
     tweaksLeft: (n: number) => `${n} tweak${n === 1 ? '' : 's'} left`,
     noTweaks: 'No tweaks left for this CV — upload again to start fresh.',
-    limitNote: '2 CVs per 24 hours · 3 tweaks each.',
+    limitNote: '2 CVs per 24 hours · 3 tweaks each. Typos and tone are fixed automatically.',
+    questionsTitle: 'A few questions to sharpen your CV',
+    questionsHint: 'Answer any of these in the box below — each answer uses one tweak. Or skip them.',
   },
   ar: {
     intro: 'أعِد بناء سيرتك لمسح المجنِّد الذي يستغرق ١٠ ثوانٍ — إشارة فقط بلا ضجيج. ارفع سيرتك الحالية ونعيد كتابتها في قالب نظيف متوافق مع أنظمة التتبّع.',
@@ -65,7 +67,9 @@ const STR = {
     applying: 'جارٍ التطبيق…',
     tweaksLeft: (n: number) => `${n === 1 ? 'تعديل واحد متبقٍّ' : `${n} تعديلات متبقّية`}`,
     noTweaks: 'لا تعديلات متبقّية لهذه السيرة — ارفع من جديد للبدء من الصفر.',
-    limitNote: 'سيرتان كل ٢٤ ساعة · ٣ تعديلات لكلٍّ.',
+    limitNote: 'سيرتان كل ٢٤ ساعة · ٣ تعديلات لكلٍّ. تُصحَّح الأخطاء والنبرة تلقائيًا.',
+    questionsTitle: 'أسئلة قليلة لتحسين سيرتك',
+    questionsHint: 'أجِب عن أيٍّ منها في الصندوق أدناه — كل إجابة تستهلك تعديلًا. أو تجاوزها.',
   },
 }
 
@@ -82,6 +86,7 @@ export default function CvGeneratorTool() {
   const [cv, setCv] = useState<Cv | null>(null)
   const [err, setErr] = useState('')
   const [refinesLeft, setRefinesLeft] = useState(0)
+  const [questions, setQuestions] = useState<string[]>([])
   const [instruction, setInstruction] = useState('')
   const [refining, setRefining] = useState(false)
   const btnRef = useRef<HTMLDivElement>(null)
@@ -136,9 +141,10 @@ export default function CvGeneratorTool() {
     setStatus('generating')
     setErr('')
     try {
-      const { cv: result, refinesLeft: left } = await generateCv(idToken, text)
+      const { cv: result, refinesLeft: left, questions: qs } = await generateCv(idToken, text)
       setCv(result)
       setRefinesLeft(left)
+      setQuestions(qs)
       setInstruction('')
       setStatus('done')
     } catch (e) {
@@ -152,9 +158,10 @@ export default function CvGeneratorTool() {
     setRefining(true)
     setErr('')
     try {
-      const { cv: result, refinesLeft: left } = await refineCv(idToken, cv, instruction.trim())
+      const { cv: result, refinesLeft: left, questions: qs } = await refineCv(idToken, cv, instruction.trim())
       setCv(result)
       setRefinesLeft(left)
+      setQuestions(qs)
       setInstruction('')
     } catch (e) {
       setErr((e as Error).message || s.genErr)
@@ -238,6 +245,15 @@ export default function CvGeneratorTool() {
 
               {/* Fine-tune loop — up to 3 instruction tweaks, preview updates live */}
               <div className="flex flex-col gap-2 border-t border-[color:var(--line-soft)] pt-3">
+                {questions.length > 0 && (
+                  <div className="flex flex-col gap-1.5 rounded-md border-s-2 border-green-600 bg-[color-mix(in_srgb,var(--green-400)_9%,transparent)] px-3 py-2.5" data-testid="cv-questions">
+                    <span className="text-[0.82rem] font-semibold text-green-700">{s.questionsTitle}</span>
+                    <ul className="list-disc ps-5 text-[0.88rem] text-ink-soft flex flex-col gap-1">
+                      {questions.map((q, i) => <li key={i}>{q}</li>)}
+                    </ul>
+                    <span className="text-[0.78rem] text-ink-faint">{s.questionsHint}</span>
+                  </div>
+                )}
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-[0.82rem] font-semibold text-ink-soft">{s.refineTitle}</span>
                   {refinesLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.tweaksLeft(refinesLeft)}</span>}


### PR DESCRIPTION
Generation and every refine now **silently fix** typos/grammar and unprofessional / over-the-top / unclear tone. The model also returns up to **3 questions** when it spots a material gap it can't responsibly fill (e.g. claimed seniority with no evidence, conflicting dates, unexplained gap) — rendered as a callout above the fine-tune box. Answering a question consumes one of the 3 polish turns; the loop re-evaluates remaining questions each turn.

Response shape is now { cv, questions, refinesLeft } across cv-generate + cv-refine. Typecheck + build + node --check green.