### PR TITLE
CV Generator: separate answer (5) vs polish (3) budgets

### DIFF
--- a/functions/cv.js
+++ b/functions/cv.js
@@ -17,7 +17,9 @@ const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
 const SITE = 'https://built-in-saudi.com'
 
 const UPLOAD_LIMIT = 2 // fresh generations per rolling 24h per user
-const REFINE_LIMIT = 3 // instruction tweaks per generated CV
+const ANSWER_LIMIT = 5 // answers to the AI's own gap questions (quality-critical)
+const POLISH_LIMIT = 3 // user-initiated free-form tweaks
+const QUESTION_CAP = 5 // most questions the model may surface at once
 const WINDOW_MS = 24 * 60 * 60 * 1000
 
 function cors(req, res) {
@@ -64,7 +66,7 @@ FIX SILENTLY (do not ask, just correct):
 - Clarity: rewrite vague or confusing statements into clear ones where the meaning is reasonably inferable. Strip buzzword filler.
 
 ASK (only for MATERIAL gaps you cannot responsibly fix yourself):
-- Put up to 3 short, specific questions in "questions" when something important is missing or inconsistent and answering it would materially strengthen the CV. Examples: a role/seniority with no supporting evidence (e.g. "Developer, 3 years" but no technologies, projects or achievements listed); conflicting or impossible dates; a large unexplained employment gap; a claimed skill never evidenced.
+- Put up to 5 short, specific questions in "questions" when something important is missing or inconsistent and answering it would materially strengthen the CV. Only include a question if it is genuinely necessary for CV quality. Examples: a role/seniority with no supporting evidence (e.g. "Developer, 3 years" but no technologies, projects or achievements listed); conflicting or impossible dates; a large unexplained employment gap; a claimed skill never evidenced.
 - Do NOT ask about trivial things, and never invent facts to fill a gap. Always still produce the best CV you can from what's given — questions are additive, never blocking. If nothing material is missing, return an empty array.
 
 The CV object shape (omit a section with an empty array; omit optional strings by leaving them empty):
@@ -82,7 +84,7 @@ The CV object shape (omit a section with an empty array; omit optional strings b
   "languages": [{ "name": string, "level": string }]
 }
 
-Return ONLY JSON of the form: { "cv": { …the CV object above… }, "questions": [ up to 3 short strings ] }`
+Return ONLY JSON of the form: { "cv": { …the CV object above… }, "questions": [ up to 5 short strings ] }`
 
 const GENERATE_SYSTEM = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON. Regenerate everything — do not copy verbatim; tighten, sharpen, and fix issues silently.\n\n${RULES}`
 
@@ -147,7 +149,7 @@ async function callOpenAI(system, user) {
     // Tolerate the model returning { cv, questions } or just the CV object.
     const cvObj = parsed && parsed.cv && typeof parsed.cv === 'object' ? parsed.cv : parsed
     const questions = Array.isArray(parsed && parsed.questions)
-      ? parsed.questions.map((q) => String(q).trim()).filter(Boolean).slice(0, 3)
+      ? parsed.questions.map((q) => String(q).trim()).filter(Boolean).slice(0, QUESTION_CAP)
       : []
     return { cv: normalize(cvObj), questions }
   } catch {
@@ -161,7 +163,7 @@ function fail(res, e) {
   res.status(e && e.code ? e.code : 500).json({ error: String((e && e.message) || e) })
 }
 
-// POST { idToken, text } → { ok, cv, refinesLeft }. Fresh build; 2 per 24h.
+// POST { idToken, text } → { ok, cv, questions, answersLeft, polishLeft }. Fresh build; 2 per 24h.
 http('cvGenerate', async (req, res) => {
   cors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).send('')
@@ -181,39 +183,50 @@ http('cvGenerate', async (req, res) => {
     }
 
     const { cv, questions } = await callOpenAI(GENERATE_SYSTEM, `Here is the raw CV text. Rebuild it as JSON per the rules:\n\n${String(text).slice(0, 30000)}`)
-    // Record the successful upload and reset the refine budget for this new CV.
-    await ref.set({ uploads: [...recent, now], refineCount: 0, email: user.email, updatedAt: new Date() }, { merge: true })
-    res.json({ ok: true, cv, questions, refinesLeft: REFINE_LIMIT })
+    // Record the successful upload and reset both budgets for this new CV.
+    await ref.set({ uploads: [...recent, now], answerCount: 0, polishCount: 0, email: user.email, updatedAt: new Date() }, { merge: true })
+    res.json({ ok: true, cv, questions, answersLeft: ANSWER_LIMIT, polishLeft: POLISH_LIMIT })
   } catch (e) {
     fail(res, e)
   }
 })
 
-// POST { idToken, cv, instruction } → { ok, cv, refinesLeft }. Up to 3 per CV.
+// POST { idToken, cv, instruction, kind } → { ok, cv, questions, answersLeft, polishLeft }
+// kind 'answer' (answering the AI's gap questions, up to 5) or 'polish' (free tweak, up to 3).
 http('cvRefine', async (req, res) => {
   cors(req, res)
   if (req.method === 'OPTIONS') return res.status(204).send('')
   if (req.method !== 'POST') return res.status(405).send('POST only')
   try {
-    const { idToken, cv: current, instruction } = req.body || {}
+    const { idToken, cv: current, instruction, kind } = req.body || {}
     const user = await verifyGoogle(idToken)
     if (!user) return res.status(401).json({ error: 'sign in with Google first' })
     if (!current || typeof current !== 'object') return res.status(400).json({ error: 'missing CV' })
     if (!instruction || String(instruction).trim().length < 2) return res.status(400).json({ error: 'missing instruction' })
 
+    const isAnswer = kind === 'answer'
     const ref = db.collection(USAGE).doc(user.sub)
     const d = (await ref.get()).data() || {}
-    const used = Number(d.refineCount || 0)
-    if (used >= REFINE_LIMIT) {
-      return res.status(429).json({ error: `You’ve used all ${REFINE_LIMIT} tweaks for this CV. Upload again to start fresh.` })
+    let answerCount = Number(d.answerCount || 0)
+    let polishCount = Number(d.polishCount || 0)
+    if (isAnswer && answerCount >= ANSWER_LIMIT) {
+      return res.status(429).json({ error: `You’ve answered the maximum of ${ANSWER_LIMIT} questions for this CV.` })
+    }
+    if (!isAnswer && polishCount >= POLISH_LIMIT) {
+      return res.status(429).json({ error: `You’ve used all ${POLISH_LIMIT} polish requests for this CV. Upload again to start fresh.` })
     }
 
+    const lead = isAnswer
+      ? 'The candidate is ANSWERING one or more of your questions'
+      : 'The candidate asks you to change something (a polish request)'
     const { cv, questions } = await callOpenAI(
       REFINE_SYSTEM,
-      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\nCandidate's message: ${String(instruction).slice(0, 1000)}`,
+      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\n${lead}:\n${String(instruction).slice(0, 1000)}`,
     )
-    await ref.update({ refineCount: used + 1, updatedAt: new Date() })
-    res.json({ ok: true, cv, questions, refinesLeft: REFINE_LIMIT - (used + 1) })
+    if (isAnswer) answerCount += 1
+    else polishCount += 1
+    await ref.update({ answerCount, polishCount, updatedAt: new Date() })
+    res.json({ ok: true, cv, questions, answersLeft: ANSWER_LIMIT - answerCount, polishLeft: POLISH_LIMIT - polishCount })
   } catch (e) {
     fail(res, e)
   }

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -52,14 +52,16 @@ export function decodeJwt(token: string): { email?: string; name?: string; pictu
 export interface CvResult {
   cv: Cv
   questions: string[]
-  refinesLeft: number
+  answersLeft: number
+  polishLeft: number
 }
 
-function parseResult(data: { cv?: Cv; questions?: unknown; refinesLeft?: unknown }): CvResult {
+function parseResult(data: { cv?: Cv; questions?: unknown; answersLeft?: unknown; polishLeft?: unknown }): CvResult {
   return {
     cv: data.cv as Cv,
     questions: Array.isArray(data.questions) ? data.questions.map(String) : [],
-    refinesLeft: Number(data.refinesLeft ?? 0),
+    answersLeft: Number(data.answersLeft ?? 0),
+    polishLeft: Number(data.polishLeft ?? 0),
   }
 }
 
@@ -74,12 +76,12 @@ export async function generateCv(idToken: string, text: string): Promise<CvResul
   return parseResult(data)
 }
 
-/** Apply one message — an answer to an AI question, or an instruction. */
-export async function refineCv(idToken: string, cv: Cv, instruction: string): Promise<CvResult> {
+/** Apply one message — an answer to an AI question ('answer') or a free tweak ('polish'). */
+export async function refineCv(idToken: string, cv: Cv, instruction: string, kind: 'answer' | 'polish'): Promise<CvResult> {
   const r = await fetch(`${FN}/cv-refine`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ idToken, cv, instruction }),
+    body: JSON.stringify({ idToken, cv, instruction, kind }),
   })
   const data = await r.json().catch(() => ({}))
   if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -29,15 +29,19 @@ const STR = {
     again: 'Regenerate',
     newFile: 'Start over',
     signinErr: 'Google sign-in couldn’t load. Disable blockers and retry.',
-    refineTitle: 'Fine-tune',
-    refinePh: 'e.g. Make the summary shorter · Emphasise leadership · Drop the oldest role',
+    polishTitle: 'Polish (optional)',
+    polishPh: 'e.g. Make the summary shorter · Emphasise leadership · Drop the oldest role',
     apply: 'Apply',
     applying: 'Applying…',
-    tweaksLeft: (n: number) => `${n} tweak${n === 1 ? '' : 's'} left`,
-    noTweaks: 'No tweaks left for this CV — upload again to start fresh.',
-    limitNote: '2 CVs per 24 hours · 3 tweaks each. Typos and tone are fixed automatically.',
+    answerPh: 'Type your answer to the questions above…',
+    answerBtn: 'Send answer',
+    answering: 'Sending…',
+    answersLeftL: (n: number) => `${n} answer${n === 1 ? '' : 's'} left`,
+    polishLeftL: (n: number) => `${n} polish left`,
+    noPolish: 'No polish requests left for this CV — upload again to start fresh.',
+    limitNote: '2 CVs per 24 hours · answer up to 5 questions · 3 polish tweaks. Typos and tone are fixed automatically.',
     questionsTitle: 'A few questions to sharpen your CV',
-    questionsHint: 'Answer any of these in the box below — each answer uses one tweak. Or skip them.',
+    questionsHint: 'The more you answer, the stronger your CV. Answering doesn’t use your polish tweaks.',
   },
   ar: {
     intro: 'أعِد بناء سيرتك لمسح المجنِّد الذي يستغرق ١٠ ثوانٍ — إشارة فقط بلا ضجيج. ارفع سيرتك الحالية ونعيد كتابتها في قالب نظيف متوافق مع أنظمة التتبّع.',
@@ -61,15 +65,19 @@ const STR = {
     again: 'إعادة الإنشاء',
     newFile: 'ابدأ من جديد',
     signinErr: 'تعذّر تحميل تسجيل دخول جوجل. عطّل المانعات وأعد المحاولة.',
-    refineTitle: 'ضبط دقيق',
-    refinePh: 'مثال: اجعل الملخّص أقصر · أبرِز القيادة · احذف أقدم وظيفة',
+    polishTitle: 'تحسين (اختياري)',
+    polishPh: 'مثال: اجعل الملخّص أقصر · أبرِز القيادة · احذف أقدم وظيفة',
     apply: 'تطبيق',
     applying: 'جارٍ التطبيق…',
-    tweaksLeft: (n: number) => `${n === 1 ? 'تعديل واحد متبقٍّ' : `${n} تعديلات متبقّية`}`,
-    noTweaks: 'لا تعديلات متبقّية لهذه السيرة — ارفع من جديد للبدء من الصفر.',
-    limitNote: 'سيرتان كل ٢٤ ساعة · ٣ تعديلات لكلٍّ. تُصحَّح الأخطاء والنبرة تلقائيًا.',
+    answerPh: 'اكتب إجابتك عن الأسئلة أعلاه…',
+    answerBtn: 'إرسال الإجابة',
+    answering: 'جارٍ الإرسال…',
+    answersLeftL: (n: number) => `${n === 1 ? 'إجابة واحدة متبقّية' : `${n} إجابات متبقّية`}`,
+    polishLeftL: (n: number) => `${n === 1 ? 'تحسين واحد متبقٍّ' : `${n} تحسينات متبقّية`}`,
+    noPolish: 'لا تحسينات متبقّية لهذه السيرة — ارفع من جديد للبدء من الصفر.',
+    limitNote: 'سيرتان كل ٢٤ ساعة · أجِب حتى ٥ أسئلة · ٣ تحسينات. تُصحَّح الأخطاء والنبرة تلقائيًا.',
     questionsTitle: 'أسئلة قليلة لتحسين سيرتك',
-    questionsHint: 'أجِب عن أيٍّ منها في الصندوق أدناه — كل إجابة تستهلك تعديلًا. أو تجاوزها.',
+    questionsHint: 'كلما أجبت أكثر، كانت سيرتك أقوى. الإجابة لا تستهلك تحسيناتك.',
   },
 }
 
@@ -85,10 +93,12 @@ export default function CvGeneratorTool() {
   const [text, setText] = useState('')
   const [cv, setCv] = useState<Cv | null>(null)
   const [err, setErr] = useState('')
-  const [refinesLeft, setRefinesLeft] = useState(0)
+  const [answersLeft, setAnswersLeft] = useState(0)
+  const [polishLeft, setPolishLeft] = useState(0)
   const [questions, setQuestions] = useState<string[]>([])
+  const [answerText, setAnswerText] = useState('')
   const [instruction, setInstruction] = useState('')
-  const [refining, setRefining] = useState(false)
+  const [busy, setBusy] = useState<'' | 'answer' | 'polish'>('')
   const btnRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -141,10 +151,12 @@ export default function CvGeneratorTool() {
     setStatus('generating')
     setErr('')
     try {
-      const { cv: result, refinesLeft: left, questions: qs } = await generateCv(idToken, text)
-      setCv(result)
-      setRefinesLeft(left)
-      setQuestions(qs)
+      const r = await generateCv(idToken, text)
+      setCv(r.cv)
+      setAnswersLeft(r.answersLeft)
+      setPolishLeft(r.polishLeft)
+      setQuestions(r.questions)
+      setAnswerText('')
       setInstruction('')
       setStatus('done')
     } catch (e) {
@@ -153,20 +165,26 @@ export default function CvGeneratorTool() {
     }
   }
 
-  async function refine() {
-    if (!idToken || !cv || !instruction.trim() || refinesLeft <= 0 || refining) return
-    setRefining(true)
+  async function applyRefine(kind: 'answer' | 'polish') {
+    if (!idToken || !cv || busy) return
+    const message = kind === 'answer' ? answerText.trim() : instruction.trim()
+    if (!message) return
+    if (kind === 'answer' && answersLeft <= 0) return
+    if (kind === 'polish' && polishLeft <= 0) return
+    setBusy(kind)
     setErr('')
     try {
-      const { cv: result, refinesLeft: left, questions: qs } = await refineCv(idToken, cv, instruction.trim())
-      setCv(result)
-      setRefinesLeft(left)
-      setQuestions(qs)
-      setInstruction('')
+      const r = await refineCv(idToken, cv, message, kind)
+      setCv(r.cv)
+      setAnswersLeft(r.answersLeft)
+      setPolishLeft(r.polishLeft)
+      setQuestions(r.questions)
+      if (kind === 'answer') setAnswerText('')
+      else setInstruction('')
     } catch (e) {
       setErr((e as Error).message || s.genErr)
     } finally {
-      setRefining(false)
+      setBusy('')
     }
   }
 
@@ -243,37 +261,55 @@ export default function CvGeneratorTool() {
                 </div>
               </div>
 
-              {/* Fine-tune loop — up to 3 instruction tweaks, preview updates live */}
-              <div className="flex flex-col gap-2 border-t border-[color:var(--line-soft)] pt-3">
-                {questions.length > 0 && (
-                  <div className="flex flex-col gap-1.5 rounded-md border-s-2 border-green-600 bg-[color-mix(in_srgb,var(--green-400)_9%,transparent)] px-3 py-2.5" data-testid="cv-questions">
+              {/* AI gap-questions — answered here, own budget (up to 5) */}
+              {questions.length > 0 && answersLeft > 0 && (
+                <div className="flex flex-col gap-2 rounded-md border-s-2 border-green-600 bg-[color-mix(in_srgb,var(--green-400)_9%,transparent)] px-3 py-2.5" data-testid="cv-questions">
+                  <div className="flex items-center justify-between gap-2">
                     <span className="text-[0.82rem] font-semibold text-green-700">{s.questionsTitle}</span>
-                    <ul className="list-disc ps-5 text-[0.88rem] text-ink-soft flex flex-col gap-1">
-                      {questions.map((q, i) => <li key={i}>{q}</li>)}
-                    </ul>
-                    <span className="text-[0.78rem] text-ink-faint">{s.questionsHint}</span>
+                    <span className="text-[0.78rem] text-ink-faint">{s.answersLeftL(answersLeft)}</span>
                   </div>
-                )}
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-[0.82rem] font-semibold text-ink-soft">{s.refineTitle}</span>
-                  {refinesLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.tweaksLeft(refinesLeft)}</span>}
+                  <ul className="list-disc ps-5 text-[0.88rem] text-ink-soft flex flex-col gap-1">
+                    {questions.map((q, i) => <li key={i}>{q}</li>)}
+                  </ul>
+                  <span className="text-[0.78rem] text-ink-faint">{s.questionsHint}</span>
+                  <div className="flex flex-wrap gap-2">
+                    <Input
+                      className="grow min-w-0"
+                      value={answerText}
+                      placeholder={s.answerPh}
+                      data-testid="cv-answer"
+                      onChange={(e) => setAnswerText(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') applyRefine('answer') }}
+                    />
+                    <Button variant="primary" onClick={() => applyRefine('answer')} disabled={busy !== '' || !answerText.trim()} data-testid="cv-answer-send">
+                      {busy === 'answer' ? s.answering : s.answerBtn}
+                    </Button>
+                  </div>
                 </div>
-                {refinesLeft > 0 ? (
+              )}
+
+              {/* User-initiated polish — separate budget (up to 3) */}
+              <div className="flex flex-col gap-2 border-t border-[color:var(--line-soft)] pt-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[0.82rem] font-semibold text-ink-soft">{s.polishTitle}</span>
+                  {polishLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.polishLeftL(polishLeft)}</span>}
+                </div>
+                {polishLeft > 0 ? (
                   <div className="flex flex-wrap gap-2">
                     <Input
                       className="grow min-w-0"
                       value={instruction}
-                      placeholder={s.refinePh}
+                      placeholder={s.polishPh}
                       data-testid="cv-instruction"
                       onChange={(e) => setInstruction(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === 'Enter') refine() }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') applyRefine('polish') }}
                     />
-                    <Button variant="primary" onClick={refine} disabled={refining || !instruction.trim()} data-testid="cv-refine">
-                      {refining ? s.applying : s.apply}
+                    <Button variant="primary" onClick={() => applyRefine('polish')} disabled={busy !== '' || !instruction.trim()} data-testid="cv-refine">
+                      {busy === 'polish' ? s.applying : s.apply}
                     </Button>
                   </div>
                 ) : (
-                  <p className="text-[0.82rem] text-ink-faint">{s.noTweaks}</p>
+                  <p className="text-[0.82rem] text-ink-faint">{s.noPolish}</p>
                 )}
               </div>
 


### PR DESCRIPTION
Splits the single refine budget into two independent, server-tracked budgets per generated CV: **5 answers** to the AI's own gap questions (quality-critical) and **3 user polishes**. Model may surface up to 5 questions. `cv-refine` now takes `kind: 'answer' | 'polish'`; response carries `answersLeft` + `polishLeft`. UI splits into an answer box (in the questions callout) and a polish box, each with its own counter. Typecheck + build + node --check green.