### PR TITLE
CV Generator UX: hero, upload-first, sequential chat Q&A

### DIFF
--- a/functions/cv.js
+++ b/functions/cv.js
@@ -88,7 +88,7 @@ Return ONLY JSON of the form: { "cv": { …the CV object above… }, "questions"
 
 const GENERATE_SYSTEM = `You are an elite technical résumé editor. You receive the raw text of a person's existing CV and you REBUILD it from scratch as JSON. Regenerate everything — do not copy verbatim; tighten, sharpen, and fix issues silently.\n\n${RULES}`
 
-const REFINE_SYSTEM = `You are an elite technical résumé editor in a short back-and-forth with the candidate. You are given the current CV as JSON plus their message — which is EITHER an answer to one of your earlier questions OR an instruction to change something. Incorporate it: if it answers a gap, weave the new information in and drop that question; if it's an instruction, apply it. Preserve everything untouched, keep the EXACT same CV shape, keep obeying every rule, keep fixing issues silently, and re-evaluate remaining questions.\n\n${RULES}`
+const REFINE_SYSTEM = `You are an elite technical résumé editor in a short back-and-forth with the candidate. You are given the current CV as JSON plus their message — which is EITHER an answer to one of your earlier questions OR an instruction to change something. Incorporate it: if it answers a gap, weave the new information in and drop that question; if it's an instruction, apply it. Preserve everything untouched, keep the EXACT same CV shape, keep obeying every rule, keep fixing issues silently, and re-evaluate remaining questions.\n\n${RULES}\n\nADDITIONALLY, include a "summary": ONE short past-tense sentence stating the concrete change you made to the CV (e.g. "Added your core stack — Java, Spring Boot, Kafka — to Skills and the Morgan Stanley role."). Return { "cv": { …the CV object… }, "questions": [ up to 5 strings ], "summary": "…" }.`
 
 function normalize(cv) {
   const arr = (x) => (Array.isArray(x) ? x : [])
@@ -151,7 +151,8 @@ async function callOpenAI(system, user) {
     const questions = Array.isArray(parsed && parsed.questions)
       ? parsed.questions.map((q) => String(q).trim()).filter(Boolean).slice(0, QUESTION_CAP)
       : []
-    return { cv: normalize(cvObj), questions }
+    const summary = typeof (parsed && parsed.summary) === 'string' ? parsed.summary.trim() : ''
+    return { cv: normalize(cvObj), questions, summary }
   } catch {
     const e = new Error('AI returned malformed JSON')
     e.code = 502
@@ -219,14 +220,14 @@ http('cvRefine', async (req, res) => {
     const lead = isAnswer
       ? 'The candidate is ANSWERING one or more of your questions'
       : 'The candidate asks you to change something (a polish request)'
-    const { cv, questions } = await callOpenAI(
+    const { cv, questions, summary } = await callOpenAI(
       REFINE_SYSTEM,
       `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\n${lead}:\n${String(instruction).slice(0, 1000)}`,
     )
     if (isAnswer) answerCount += 1
     else polishCount += 1
     await ref.update({ answerCount, polishCount, updatedAt: new Date() })
-    res.json({ ok: true, cv, questions, answersLeft: ANSWER_LIMIT - answerCount, polishLeft: POLISH_LIMIT - polishCount })
+    res.json({ ok: true, cv, questions, summary, answersLeft: ANSWER_LIMIT - answerCount, polishLeft: POLISH_LIMIT - polishCount })
   } catch (e) {
     fail(res, e)
   }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -180,6 +180,15 @@ export function CalendarIcon({ className }: P) {
   )
 }
 
+export function MicIcon({ className }: P) {
+  return (
+    <svg {...base} className={className} aria-hidden="true">
+      <rect x="9" y="3" width="6" height="11" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0M12 18v3" />
+    </svg>
+  )
+}
+
 export function CvIcon({ className }: P) {
   return (
     <svg {...base} className={className} aria-hidden="true">

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -52,14 +52,16 @@ export function decodeJwt(token: string): { email?: string; name?: string; pictu
 export interface CvResult {
   cv: Cv
   questions: string[]
+  summary: string
   answersLeft: number
   polishLeft: number
 }
 
-function parseResult(data: { cv?: Cv; questions?: unknown; answersLeft?: unknown; polishLeft?: unknown }): CvResult {
+function parseResult(data: { cv?: Cv; questions?: unknown; summary?: unknown; answersLeft?: unknown; polishLeft?: unknown }): CvResult {
   return {
     cv: data.cv as Cv,
     questions: Array.isArray(data.questions) ? data.questions.map(String) : [],
+    summary: typeof data.summary === 'string' ? data.summary : '',
     answersLeft: Number(data.answersLeft ?? 0),
     polishLeft: Number(data.polishLeft ?? 0),
   }

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -1,93 +1,168 @@
 import { useEffect, useRef, useState, type ChangeEvent } from 'react'
 import { useLocale } from '../../i18n'
-import { Button, Panel, Stack, Input } from '../../components/ui'
-import { DownloadIcon } from '../../components/icons'
+import { Button, Input, Stack } from '../../components/ui'
+import { DownloadIcon, MicIcon } from '../../components/icons'
 import { loadGis, GOOGLE_CLIENT_ID, decodeJwt, generateCv, refineCv } from '../../lib/cvApi'
 import { renderCvHtml, renderCvWordBlob } from './template'
 import { cvFilename, type Cv } from './schema'
 
+// Minimal Web Speech API surface (optional voice input).
+type SR = { lang: string; interimResults: boolean; onresult: ((e: unknown) => void) | null; onend: (() => void) | null; start(): void; stop(): void }
+const SpeechRecCtor: (new () => SR) | undefined =
+  typeof window !== 'undefined'
+    ? ((window as unknown as { SpeechRecognition?: new () => SR; webkitSpeechRecognition?: new () => SR }).SpeechRecognition ||
+       (window as unknown as { webkitSpeechRecognition?: new () => SR }).webkitSpeechRecognition)
+    : undefined
+
 const STR = {
   en: {
-    intro: 'Rebuild your CV for the 10-second recruiter scan — signal only, no noise. Upload your current CV; we rewrite it into a clean, ATS-ready template.',
-    why: 'The purpose of a CV is not to get the job — it’s to get the interview. We strip the noise (photos, colours, GPAs, references, exact address, month-level dates) and keep only what earns a second look.',
-    signin: 'Sign in with Google to continue',
-    signinNote: 'Sign-in keeps this free tool from being abused. We only read your name and email — nothing is posted anywhere.',
-    signedInAs: (e: string) => `Signed in as ${e}`,
+    heroKicker: 'CV Generator',
+    heroTitle: 'Make your CV easy to say yes to',
+    heroBody: 'A recruiter skims a CV in seconds, so it has to put your strongest points first. This tool rewrites the CV you already have into a short, clear version — then asks a couple of quick questions to fill any gaps. Start by uploading your CV below.',
     upload: 'Upload your CV',
-    uploadHint: 'PDF, Word (.docx) or plain text. It’s read in your browser — only the extracted text is sent for rewriting.',
+    uploadHint: 'PDF, Word (.docx) or text — read right here in your browser.',
     choose: 'Choose file',
     extracting: 'Reading your CV…',
-    extracted: (n: number) => `Extracted ${n.toLocaleString()} characters.`,
-    tooShort: 'Couldn’t read enough text from that file. Try a text-based PDF or a .docx.',
+    extracted: (n: number) => `Got it — read ${n.toLocaleString()} characters.`,
+    tooShort: 'Couldn’t read enough text. Try a text-based PDF or a .docx.',
     extractErr: 'Couldn’t read that file. Try a PDF, .docx or .txt.',
-    generate: 'Generate my CV',
-    generating: 'Rewriting your CV…',
-    genErr: 'Generation failed. Please try again.',
-    result: 'Your rebuilt CV',
+    loginNote: 'Quick sign-in to build it — free, just to keep bots out.',
+    build: 'Build my CV',
+    building: 'Building your CV…',
+    genErr: 'Something went wrong. Please try again.',
+    result: 'Your CV',
     pdf: 'Save as PDF',
     word: 'Download Word',
-    again: 'Regenerate',
-    newFile: 'Start over',
-    signinErr: 'Google sign-in couldn’t load. Disable blockers and retry.',
-    polishTitle: 'Polish (optional)',
-    polishPh: 'e.g. Make the summary shorter · Emphasise leadership · Drop the oldest role',
+    changesTitle: 'Improvements made',
+    qLabel: (i: number, n: number) => `Question ${i} of ${n}`,
+    answerPh: 'Type or speak your answer…',
+    send: 'Send',
+    sending: 'Sending…',
+    skip: 'Skip this',
+    answersLeftL: (n: number) => `${n} left`,
+    polishTitle: 'Anything else to adjust?',
+    polishPh: 'e.g. Make the summary shorter · Emphasise leadership',
     apply: 'Apply',
     applying: 'Applying…',
-    answerPh: 'Type your answer to the questions above…',
-    answerBtn: 'Send answer',
-    answering: 'Sending…',
-    answersLeftL: (n: number) => `${n} answer${n === 1 ? '' : 's'} left`,
-    polishLeftL: (n: number) => `${n} polish left`,
-    noPolish: 'No polish requests left for this CV — upload again to start fresh.',
-    limitNote: '2 CVs per 24 hours · answer up to 5 questions · 3 polish tweaks. Typos and tone are fixed automatically.',
-    questionsTitle: 'A few questions to sharpen your CV',
-    questionsHint: 'The more you answer, the stronger your CV. Answering doesn’t use your polish tweaks.',
+    polishLeftL: (n: number) => `${n} tweak${n === 1 ? '' : 's'} left`,
+    noPolish: 'That’s all your tweaks — upload again to start fresh.',
+    startOver: 'Start over',
+    signinErr: 'Google sign-in couldn’t load. Disable blockers and retry.',
+    voice: 'Voice input',
   },
   ar: {
-    intro: 'أعِد بناء سيرتك لمسح المجنِّد الذي يستغرق ١٠ ثوانٍ — إشارة فقط بلا ضجيج. ارفع سيرتك الحالية ونعيد كتابتها في قالب نظيف متوافق مع أنظمة التتبّع.',
-    why: 'هدف السيرة ليس الحصول على الوظيفة — بل الحصول على المقابلة. نزيل الضجيج (الصور والألوان والمعدّلات والمراجع والعنوان الدقيق وتواريخ الأشهر) ونُبقي ما يستحق نظرة ثانية.',
-    signin: 'سجّل الدخول بجوجل للمتابعة',
-    signinNote: 'تسجيل الدخول يمنع إساءة استخدام هذه الأداة المجانية. نقرأ اسمك وبريدك فقط، ولا يُنشر أي شيء.',
-    signedInAs: (e: string) => `مسجّل باسم ${e}`,
+    heroKicker: 'منشئ السيرة الذاتية',
+    heroTitle: 'اجعل سيرتك سهلة القبول',
+    heroBody: 'يتصفّح المجنِّد السيرة في ثوانٍ، لذا يجب أن تُبرز أقوى نقاطك أولًا. تعيد هذه الأداة كتابة سيرتك الحالية في نسخة قصيرة وواضحة — ثم تطرح سؤالين سريعين لسدّ أي ثغرات. ابدأ برفع سيرتك أدناه.',
     upload: 'ارفع سيرتك الذاتية',
-    uploadHint: 'PDF أو Word‏ (.docx) أو نص. تُقرأ داخل متصفحك — ويُرسَل النص المستخرج فقط لإعادة الكتابة.',
+    uploadHint: 'PDF أو Word‏ (.docx) أو نص — تُقرأ هنا داخل متصفحك.',
     choose: 'اختر ملفًا',
     extracting: 'جارٍ قراءة سيرتك…',
-    extracted: (n: number) => `استُخرج ${n.toLocaleString()} حرفًا.`,
-    tooShort: 'تعذّرت قراءة نص كافٍ من الملف. جرّب PDF نصيًا أو .docx.',
+    extracted: (n: number) => `تمّ — قُرئ ${n.toLocaleString()} حرفًا.`,
+    tooShort: 'تعذّرت قراءة نص كافٍ. جرّب PDF نصيًا أو .docx.',
     extractErr: 'تعذّرت قراءة الملف. جرّب PDF أو .docx أو .txt.',
-    generate: 'أنشئ سيرتي',
-    generating: 'جارٍ إعادة كتابة سيرتك…',
-    genErr: 'فشل الإنشاء. حاول مرة أخرى.',
-    result: 'سيرتك بعد إعادة البناء',
+    loginNote: 'تسجيل دخول سريع للبناء — مجاني، فقط لمنع الروبوتات.',
+    build: 'ابنِ سيرتي',
+    building: 'جارٍ بناء سيرتك…',
+    genErr: 'حدث خطأ ما. حاول مرة أخرى.',
+    result: 'سيرتك',
     pdf: 'حفظ PDF',
     word: 'تنزيل Word',
-    again: 'إعادة الإنشاء',
-    newFile: 'ابدأ من جديد',
-    signinErr: 'تعذّر تحميل تسجيل دخول جوجل. عطّل المانعات وأعد المحاولة.',
-    polishTitle: 'تحسين (اختياري)',
-    polishPh: 'مثال: اجعل الملخّص أقصر · أبرِز القيادة · احذف أقدم وظيفة',
+    changesTitle: 'التحسينات المُطبَّقة',
+    qLabel: (i: number, n: number) => `سؤال ${i} من ${n}`,
+    answerPh: 'اكتب أو انطق إجابتك…',
+    send: 'إرسال',
+    sending: 'جارٍ الإرسال…',
+    skip: 'تخطَّ هذا',
+    answersLeftL: (n: number) => `${n} متبقٍّ`,
+    polishTitle: 'أي شيء آخر لتعديله؟',
+    polishPh: 'مثال: اجعل الملخّص أقصر · أبرِز القيادة',
     apply: 'تطبيق',
     applying: 'جارٍ التطبيق…',
-    answerPh: 'اكتب إجابتك عن الأسئلة أعلاه…',
-    answerBtn: 'إرسال الإجابة',
-    answering: 'جارٍ الإرسال…',
-    answersLeftL: (n: number) => `${n === 1 ? 'إجابة واحدة متبقّية' : `${n} إجابات متبقّية`}`,
-    polishLeftL: (n: number) => `${n === 1 ? 'تحسين واحد متبقٍّ' : `${n} تحسينات متبقّية`}`,
-    noPolish: 'لا تحسينات متبقّية لهذه السيرة — ارفع من جديد للبدء من الصفر.',
-    limitNote: 'سيرتان كل ٢٤ ساعة · أجِب حتى ٥ أسئلة · ٣ تحسينات. تُصحَّح الأخطاء والنبرة تلقائيًا.',
-    questionsTitle: 'أسئلة قليلة لتحسين سيرتك',
-    questionsHint: 'كلما أجبت أكثر، كانت سيرتك أقوى. الإجابة لا تستهلك تحسيناتك.',
+    polishLeftL: (n: number) => `${n === 1 ? 'تعديل واحد متبقٍّ' : `${n} تعديلات متبقّية`}`,
+    noPolish: 'انتهت تعديلاتك — ارفع من جديد للبدء من الصفر.',
+    startOver: 'ابدأ من جديد',
+    signinErr: 'تعذّر تحميل تسجيل دخول جوجل. عطّل المانعات وأعد المحاولة.',
+    voice: 'إدخال صوتي',
   },
 }
 
-type Status = 'idle' | 'extracting' | 'ready' | 'generating' | 'done' | 'error'
+type Status = 'idle' | 'extracting' | 'ready' | 'generating' | 'done'
+
+/** Text field with an optional speech-to-text mic + a send button. */
+function ChatInput({
+  value, setValue, onSend, placeholder, busy, sendLabel, testid, locale,
+}: {
+  value: string
+  setValue: (v: string) => void
+  onSend: () => void
+  placeholder: string
+  busy: boolean
+  sendLabel: string
+  testid: string
+  locale: 'en' | 'ar'
+}) {
+  const recRef = useRef<SR | null>(null)
+  const [listening, setListening] = useState(false)
+  const voiceLabel = STR[locale].voice
+
+  function toggleMic() {
+    if (!SpeechRecCtor) return
+    if (listening) {
+      recRef.current?.stop()
+      setListening(false)
+      return
+    }
+    const rec = new SpeechRecCtor()
+    rec.lang = locale === 'ar' ? 'ar-SA' : 'en-US'
+    rec.interimResults = false
+    rec.onresult = (e: unknown) => {
+      const t = (e as { results?: Array<Array<{ transcript?: string }>> })?.results?.[0]?.[0]?.transcript || ''
+      if (t) setValue(value ? `${value} ${t}` : t)
+    }
+    rec.onend = () => setListening(false)
+    try {
+      rec.start()
+      recRef.current = rec
+      setListening(true)
+    } catch {
+      setListening(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <div className="relative grow min-w-0 flex items-center">
+        <Input
+          className={SpeechRecCtor ? 'pe-11' : ''}
+          value={value}
+          placeholder={placeholder}
+          data-testid={testid}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') onSend() }}
+        />
+        {SpeechRecCtor && (
+          <button
+            type="button"
+            aria-label={voiceLabel}
+            aria-pressed={listening}
+            onClick={toggleMic}
+            className={`absolute end-1.5 inline-flex items-center justify-center size-8 rounded-full border-0 bg-transparent cursor-pointer ${listening ? 'text-green-600 bg-[color-mix(in_srgb,var(--green-400)_20%,transparent)]' : 'text-ink-faint hover:text-ink-soft'}`}
+          >
+            <MicIcon className="size-[18px]" />
+          </button>
+        )}
+      </div>
+      <Button variant="primary" onClick={onSend} disabled={busy || !value.trim()}>{sendLabel}</Button>
+    </div>
+  )
+}
 
 export default function CvGeneratorTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const [idToken, setIdToken] = useState<string | null>(null)
-  const [email, setEmail] = useState('')
+  const [gisReady, setGisReady] = useState(false)
   const [status, setStatus] = useState<Status>('idle')
   const [fileName, setFileName] = useState('')
   const [text, setText] = useState('')
@@ -95,12 +170,17 @@ export default function CvGeneratorTool() {
   const [err, setErr] = useState('')
   const [answersLeft, setAnswersLeft] = useState(0)
   const [polishLeft, setPolishLeft] = useState(0)
-  const [questions, setQuestions] = useState<string[]>([])
+  const [queue, setQueue] = useState<string[]>([])
+  const [qIndex, setQIndex] = useState(0)
+  const [changes, setChanges] = useState<string[]>([])
   const [answerText, setAnswerText] = useState('')
   const [instruction, setInstruction] = useState('')
   const [busy, setBusy] = useState<'' | 'answer' | 'polish'>('')
   const btnRef = useRef<HTMLDivElement>(null)
+  const gisRef = useRef<{ renderButton: (el: HTMLElement, o: Record<string, unknown>) => void } | null>(null)
+  const activeRef = useRef<HTMLDivElement>(null)
 
+  // Load + init Google Identity Services once (but don't force sign-in yet).
   useEffect(() => {
     let cancelled = false
     loadGis()
@@ -108,19 +188,30 @@ export default function CvGeneratorTool() {
         if (cancelled) return
         id.initialize({
           client_id: GOOGLE_CLIENT_ID,
-          callback: (r) => {
-            setIdToken(r.credential)
-            setEmail(decodeJwt(r.credential).email || '')
-          },
+          callback: (r) => { setIdToken(r.credential); decodeJwt(r.credential) },
         })
-        if (btnRef.current) id.renderButton(btnRef.current, { theme: 'filled_blue', size: 'large', text: 'signin_with', shape: 'pill' })
+        gisRef.current = id
+        setGisReady(true)
       })
       .catch(() => setErr(s.signinErr))
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Render the Google button whenever the sign-in prompt is on screen.
+  useEffect(() => {
+    if (gisReady && !idToken && btnRef.current && gisRef.current) {
+      btnRef.current.innerHTML = ''
+      gisRef.current.renderButton(btnRef.current, { theme: 'filled_blue', size: 'large', text: 'signin_with', shape: 'pill' })
+    }
+  }, [gisReady, idToken, text, status])
+
+  // Auto-scroll to the active question / polish section after each step.
+  useEffect(() => {
+    if (status === 'done' && activeRef.current) {
+      activeRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [qIndex, status])
 
   async function onFile(e: ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0]
@@ -133,11 +224,7 @@ export default function CvGeneratorTool() {
     try {
       const { extractText } = await import('./extract')
       const t = await extractText(f)
-      if (!t || t.length < 60) {
-        setErr(s.tooShort)
-        setStatus('idle')
-        return
-      }
+      if (!t || t.length < 60) { setErr(s.tooShort); setStatus('idle'); return }
       setText(t)
       setStatus('ready')
     } catch {
@@ -155,7 +242,9 @@ export default function CvGeneratorTool() {
       setCv(r.cv)
       setAnswersLeft(r.answersLeft)
       setPolishLeft(r.polishLeft)
-      setQuestions(r.questions)
+      setQueue(r.questions)
+      setQIndex(0)
+      setChanges([])
       setAnswerText('')
       setInstruction('')
       setStatus('done')
@@ -165,27 +254,59 @@ export default function CvGeneratorTool() {
     }
   }
 
-  async function applyRefine(kind: 'answer' | 'polish') {
-    if (!idToken || !cv || busy) return
-    const message = kind === 'answer' ? answerText.trim() : instruction.trim()
-    if (!message) return
-    if (kind === 'answer' && answersLeft <= 0) return
-    if (kind === 'polish' && polishLeft <= 0) return
-    setBusy(kind)
+  const currentQ = status === 'done' && qIndex < queue.length && answersLeft > 0 ? queue[qIndex] : null
+
+  async function answer() {
+    if (!idToken || !cv || !currentQ || !answerText.trim() || busy) return
+    setBusy('answer')
     setErr('')
     try {
-      const r = await refineCv(idToken, cv, message, kind)
+      const r = await refineCv(idToken, cv, `Question: ${currentQ}\nAnswer: ${answerText.trim()}`, 'answer')
       setCv(r.cv)
       setAnswersLeft(r.answersLeft)
-      setPolishLeft(r.polishLeft)
-      setQuestions(r.questions)
-      if (kind === 'answer') setAnswerText('')
-      else setInstruction('')
+      if (r.summary) setChanges((c) => [...c, r.summary])
+      setAnswerText('')
+      setQIndex((i) => i + 1)
     } catch (e) {
       setErr((e as Error).message || s.genErr)
     } finally {
       setBusy('')
     }
+  }
+
+  function skip() {
+    setAnswerText('')
+    setQIndex((i) => i + 1)
+  }
+
+  async function polish() {
+    if (!idToken || !cv || !instruction.trim() || polishLeft <= 0 || busy) return
+    setBusy('polish')
+    setErr('')
+    try {
+      const r = await refineCv(idToken, cv, instruction.trim(), 'polish')
+      setCv(r.cv)
+      setPolishLeft(r.polishLeft)
+      if (r.summary) setChanges((c) => [...c, r.summary])
+      setInstruction('')
+    } catch (e) {
+      setErr((e as Error).message || s.genErr)
+    } finally {
+      setBusy('')
+    }
+  }
+
+  function startOver() {
+    setCv(null)
+    setText('')
+    setFileName('')
+    setQueue([])
+    setQIndex(0)
+    setChanges([])
+    setAnswerText('')
+    setInstruction('')
+    setErr('')
+    setStatus('idle')
   }
 
   function exportPdf() {
@@ -195,10 +316,7 @@ export default function CvGeneratorTool() {
     w.document.write(renderCvHtml(cv))
     w.document.title = cvFilename(cv)
     w.document.close()
-    setTimeout(() => {
-      w.focus()
-      w.print()
-    }, 500)
+    setTimeout(() => { w.focus(); w.print() }, 500)
   }
 
   function exportWord() {
@@ -212,24 +330,27 @@ export default function CvGeneratorTool() {
     setTimeout(() => URL.revokeObjectURL(a.href), 1000)
   }
 
+  // Full-bleed green intro, docked flush to the navbar (cancels the page's top padding).
+  const hero = (
+    <div className="mx-[calc(50%-50vw)] w-screen max-w-[100vw] mt-[calc(clamp(1.5rem,4vw,2.5rem)*-1)] bg-green-600 text-sand-100">
+      <div className="wrap py-[clamp(1.6rem,4.5vw,2.4rem)] flex flex-col gap-2">
+        <span className="text-[0.72rem] font-semibold uppercase tracking-[0.16em] opacity-75">{s.heroKicker}</span>
+        <h1 className="font-display rtl:font-ar text-[clamp(1.5rem,4.5vw,2.1rem)] font-bold leading-tight">{s.heroTitle}</h1>
+        <p className="text-[0.98rem] leading-relaxed opacity-90 max-w-[46rem]">{s.heroBody}</p>
+      </div>
+    </div>
+  )
+
   return (
     <Stack data-testid="cv-generator">
-      <p className="text-[0.95rem] text-ink-soft">{s.intro}</p>
-
-      {!idToken ? (
-        <Panel>
-          <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.signin}</span>
-          <div ref={btnRef} className="[color-scheme:light]" data-testid="google-signin" />
-          <p className="text-[0.82rem] text-ink-faint">{s.signinNote}</p>
-          {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
-        </Panel>
-      ) : (
+      {status !== 'done' && (
         <>
-          <p className="text-[0.82rem] text-ink-faint">{s.signedInAs(email)}</p>
+          {hero}
 
-          <Panel>
+          {/* Upload — before any sign-in */}
+          <div className="flex flex-col gap-2">
             <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.upload}</span>
-            <p className="text-[0.82rem] text-ink-faint">{s.uploadHint} {s.limitNote}</p>
+            <p className="text-[0.82rem] text-ink-faint">{s.uploadHint}</p>
             <div className="flex flex-wrap items-center gap-3">
               <label className="inline-flex">
                 <input type="file" accept=".pdf,.docx,.txt,.md,text/plain,application/pdf" className="sr-only" onChange={onFile} data-testid="cv-file" />
@@ -240,89 +361,91 @@ export default function CvGeneratorTool() {
               {fileName && <span className="text-[0.85rem] text-ink-faint font-mono truncate max-w-[16rem]">{fileName}</span>}
             </div>
             {status === 'extracting' && <p className="text-[0.85rem] text-ink-faint">{s.extracting}</p>}
-            {(status === 'ready' || status === 'generating' || status === 'done') && text && (
-              <p className="text-[0.85rem] text-green-700">{s.extracted(text.length)}</p>
-            )}
-            {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
-            {(status === 'ready' || status === 'generating' || status === 'done') && (
-              <Button variant="primary" className="self-start" onClick={generate} disabled={status === 'generating'} data-testid="cv-generate">
-                {status === 'generating' ? s.generating : status === 'done' ? s.again : s.generate}
-              </Button>
-            )}
-          </Panel>
+            {text && status !== 'extracting' && <p className="text-[0.85rem] text-green-700">{s.extracted(text.length)}</p>}
+          </div>
 
-          {cv && status === 'done' && (
-            <Panel data-testid="cv-result">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.result}</span>
-                <div className="flex flex-wrap gap-2">
-                  <Button variant="primary" onClick={exportPdf} data-testid="cv-pdf"><DownloadIcon /> {s.pdf}</Button>
-                  <Button onClick={exportWord} data-testid="cv-word"><DownloadIcon /> {s.word}</Button>
-                </div>
-              </div>
-
-              {/* AI gap-questions — answered here, own budget (up to 5) */}
-              {questions.length > 0 && answersLeft > 0 && (
-                <div className="flex flex-col gap-2 rounded-md border-s-2 border-green-600 bg-[color-mix(in_srgb,var(--green-400)_9%,transparent)] px-3 py-2.5" data-testid="cv-questions">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[0.82rem] font-semibold text-green-700">{s.questionsTitle}</span>
-                    <span className="text-[0.78rem] text-ink-faint">{s.answersLeftL(answersLeft)}</span>
-                  </div>
-                  <ul className="list-disc ps-5 text-[0.88rem] text-ink-soft flex flex-col gap-1">
-                    {questions.map((q, i) => <li key={i}>{q}</li>)}
-                  </ul>
-                  <span className="text-[0.78rem] text-ink-faint">{s.questionsHint}</span>
-                  <div className="flex flex-wrap gap-2">
-                    <Input
-                      className="grow min-w-0"
-                      value={answerText}
-                      placeholder={s.answerPh}
-                      data-testid="cv-answer"
-                      onChange={(e) => setAnswerText(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === 'Enter') applyRefine('answer') }}
-                    />
-                    <Button variant="primary" onClick={() => applyRefine('answer')} disabled={busy !== '' || !answerText.trim()} data-testid="cv-answer-send">
-                      {busy === 'answer' ? s.answering : s.answerBtn}
-                    </Button>
-                  </div>
-                </div>
-              )}
-
-              {/* User-initiated polish — separate budget (up to 3) */}
-              <div className="flex flex-col gap-2 border-t border-[color:var(--line-soft)] pt-3">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-[0.82rem] font-semibold text-ink-soft">{s.polishTitle}</span>
-                  {polishLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.polishLeftL(polishLeft)}</span>}
-                </div>
-                {polishLeft > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    <Input
-                      className="grow min-w-0"
-                      value={instruction}
-                      placeholder={s.polishPh}
-                      data-testid="cv-instruction"
-                      onChange={(e) => setInstruction(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === 'Enter') applyRefine('polish') }}
-                    />
-                    <Button variant="primary" onClick={() => applyRefine('polish')} disabled={busy !== '' || !instruction.trim()} data-testid="cv-refine">
-                      {busy === 'polish' ? s.applying : s.apply}
-                    </Button>
-                  </div>
-                ) : (
-                  <p className="text-[0.82rem] text-ink-faint">{s.noPolish}</p>
-                )}
-              </div>
-
-              <iframe
-                title={s.result}
-                className="w-full h-[75vh] rounded-md border border-[color:var(--line-soft)] bg-white"
-                srcDoc={renderCvHtml(cv)}
-              />
-              <p className="text-[0.8rem] text-ink-faint">{s.pdf}: {cvFilename(cv)}.pdf</p>
-            </Panel>
+          {/* Sign-in appears only once a CV is ready — kept minimal */}
+          {text && !idToken && (
+            <div className="flex flex-col gap-2">
+              <div ref={btnRef} className="[color-scheme:light]" data-testid="google-signin" />
+              <p className="text-[0.8rem] text-ink-faint">{s.loginNote}</p>
+            </div>
           )}
 
-          <p className="text-[0.82rem] text-ink-faint">{s.why}</p>
+          {/* Build */}
+          {text && idToken && (
+            <Button variant="primary" className="self-start" onClick={generate} disabled={status === 'generating'} data-testid="cv-generate">
+              {status === 'generating' ? s.building : s.build}
+            </Button>
+          )}
+
+          {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
+        </>
+      )}
+
+      {status === 'done' && cv && (
+        <>
+          {/* Live preview + export */}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="text-[0.82rem] font-semibold text-ink-soft tracking-[0.01em]">{s.result}</span>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="primary" onClick={exportPdf} data-testid="cv-pdf"><DownloadIcon /> {s.pdf}</Button>
+              <Button onClick={exportWord} data-testid="cv-word"><DownloadIcon /> {s.word}</Button>
+              <Button onClick={startOver} data-testid="cv-startover">{s.startOver}</Button>
+            </div>
+          </div>
+          <iframe
+            title={s.result}
+            className="w-full h-[75vh] rounded-md border border-[color:var(--line-soft)] bg-white"
+            srcDoc={renderCvHtml(cv)}
+          />
+
+          {/* Log of what was changed (question + literal answer collapse to this) */}
+          {changes.length > 0 && (
+            <div className="flex flex-col gap-1.5" data-testid="cv-changes">
+              <span className="text-[0.74rem] font-semibold uppercase tracking-[0.12em] text-ink-faint">{s.changesTitle}</span>
+              <ul className="flex flex-col gap-1">
+                {changes.map((c, i) => (
+                  <li key={i} className="flex gap-2 text-[0.88rem] text-ink-soft"><span className="text-green-600 flex-none">✓</span>{c}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Active section: one question at a time, else the polish box. Full-width bands. */}
+          <div ref={activeRef}>
+            {currentQ ? (
+              <div className="mx-[calc(50%-50vw)] w-screen max-w-[100vw] bg-[color-mix(in_srgb,var(--green-400)_9%,transparent)] border-y border-[color:var(--line-soft)]" data-testid="cv-question">
+                <div className="wrap py-[1.3rem] flex flex-col gap-2.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[0.74rem] font-semibold uppercase tracking-[0.12em] text-green-700">{s.qLabel(qIndex + 1, queue.length)}</span>
+                    <span className="text-[0.78rem] text-ink-faint">{s.answersLeftL(answersLeft)}</span>
+                  </div>
+                  <p className="font-display rtl:font-ar text-[1.1rem] text-ink leading-snug">{currentQ}</p>
+                  <ChatInput value={answerText} setValue={setAnswerText} onSend={answer} placeholder={s.answerPh}
+                    busy={busy === 'answer'} sendLabel={busy === 'answer' ? s.sending : s.send} testid="cv-answer" locale={locale} />
+                  <button type="button" className="self-start text-[0.8rem] text-ink-faint underline bg-transparent border-0 cursor-pointer p-0" onClick={skip} data-testid="cv-skip">{s.skip}</button>
+                </div>
+              </div>
+            ) : (
+              <div className="mx-[calc(50%-50vw)] w-screen max-w-[100vw] bg-[color-mix(in_srgb,var(--sand-100)_55%,transparent)] border-y border-[color:var(--line-soft)]" data-testid="cv-polish">
+                <div className="wrap py-[1.3rem] flex flex-col gap-2.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[0.82rem] font-semibold text-ink-soft">{s.polishTitle}</span>
+                    {polishLeft > 0 && <span className="text-[0.78rem] text-ink-faint">{s.polishLeftL(polishLeft)}</span>}
+                  </div>
+                  {polishLeft > 0 ? (
+                    <ChatInput value={instruction} setValue={setInstruction} onSend={polish} placeholder={s.polishPh}
+                      busy={busy === 'polish'} sendLabel={busy === 'polish' ? s.applying : s.apply} testid="cv-instruction" locale={locale} />
+                  ) : (
+                    <p className="text-[0.82rem] text-ink-faint">{s.noPolish}</p>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {err && <p className="text-[0.85rem] text-gold-500">{err}</p>}
         </>
       )}
     </Stack>


### PR DESCRIPTION
Green full-bleed intro hero (flush to navbar), upload-before-login, minimal sign-in, and a sequential one-question-at-a-time chat flow with speech-to-text. Answered questions collapse to a one-line 'improvements made' summary (new `summary` field on cv-refine); live preview throughout; auto-scroll to each new section. Typecheck + build + node --check green.