### PR TITLE
CV Generator: preview centering + refine context + prompt rules

### DIFF
--- a/functions/cv.js
+++ b/functions/cv.js
@@ -58,6 +58,8 @@ Rules (apply strictly):
 - Phone/email: raw values, no "Phone:" / "Email:" labels.
 - REMOVE entirely: photos, references, GPA, university coursework/curriculum, exact addresses, objective-statement fluff, and any irrelevant experience (e.g. unrelated retail/food jobs for an IT professional).
 - Prefer strong action-verb bullets with measurable impact. Summarise anything verbose.
+- Order experience and education MOST RECENT FIRST (reverse chronological). If you add a role, insert it at the correct chronological position — a newer role goes at the top.
+- Skill category labels must be SHORT — 1 to 3 words (e.g. "Cloud", "Languages", "Testing"). They render as a narrow table column, so never use long phrases.
 - Education: degree, institution, year only. No scores.
 - Keep it truthful — never invent employers, dates, or achievements not supported by the source.
 
@@ -200,7 +202,7 @@ http('cvRefine', async (req, res) => {
   if (req.method === 'OPTIONS') return res.status(204).send('')
   if (req.method !== 'POST') return res.status(405).send('POST only')
   try {
-    const { idToken, cv: current, instruction, kind } = req.body || {}
+    const { idToken, cv: current, instruction, kind, context } = req.body || {}
     const user = await verifyGoogle(idToken)
     if (!user) return res.status(401).json({ error: 'sign in with Google first' })
     if (!current || typeof current !== 'object') return res.status(400).json({ error: 'missing CV' })
@@ -222,9 +224,13 @@ http('cvRefine', async (req, res) => {
     const lead = isAnswer
       ? 'The candidate is ANSWERING one or more of your questions'
       : 'The candidate asks you to change something (a polish request)'
+    // The previous change, so the candidate can react to it ("no, not like that, like this").
+    const prev = typeof context === 'string' && context.trim()
+      ? `\n\nYour most recent change to this CV was: "${String(context).slice(0, 400)}". The candidate may be reacting to it — if so, correct it accordingly.`
+      : ''
     const { cv, questions, summary } = await callOpenAI(
       REFINE_SYSTEM,
-      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}\n\n${lead}:\n${String(instruction).slice(0, 1000)}`,
+      `Current CV JSON:\n${JSON.stringify(normalize(current)).slice(0, 30000)}${prev}\n\n${lead}:\n${String(instruction).slice(0, 1000)}`,
     )
     if (isAnswer) answerCount += 1
     else polishCount += 1

--- a/src/lib/cvApi.ts
+++ b/src/lib/cvApi.ts
@@ -78,12 +78,13 @@ export async function generateCv(idToken: string, text: string): Promise<CvResul
   return parseResult(data)
 }
 
-/** Apply one message — an answer to an AI question ('answer') or a free tweak ('polish'). */
-export async function refineCv(idToken: string, cv: Cv, instruction: string, kind: 'answer' | 'polish'): Promise<CvResult> {
+/** Apply one message — an answer to an AI question ('answer') or a free tweak ('polish').
+ *  `context` is the previous change summary so the user can correct it ("no, like this"). */
+export async function refineCv(idToken: string, cv: Cv, instruction: string, kind: 'answer' | 'polish', context = ''): Promise<CvResult> {
   const r = await fetch(`${FN}/cv-refine`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ idToken, cv, instruction, kind }),
+    body: JSON.stringify({ idToken, cv, instruction, kind, context }),
   })
   const data = await r.json().catch(() => ({}))
   if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`)

--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -185,6 +185,8 @@ export default function CvGeneratorTool() {
   // Guards the auto-generate effect so a failed generation never re-triggers it
   // (which would hammer the API). Reset only when a new file is uploaded.
   const autoTried = useRef(false)
+  // The previous change summary, sent as context so the user can correct it.
+  const lastChangeRef = useRef('')
 
   // Load + init Google Identity Services once (but don't force sign-in yet).
   useEffect(() => {
@@ -270,6 +272,7 @@ export default function CvGeneratorTool() {
       setQueue(r.questions)
       setQIndex(0)
       setToast('')
+      lastChangeRef.current = ''
       setAnswerText('')
       setInstruction('')
       setStatus('done')
@@ -286,10 +289,10 @@ export default function CvGeneratorTool() {
     setBusy('answer')
     setErr('')
     try {
-      const r = await refineCv(idToken, cv, `Question: ${currentQ}\nAnswer: ${answerText.trim()}`, 'answer')
+      const r = await refineCv(idToken, cv, `Question: ${currentQ}\nAnswer: ${answerText.trim()}`, 'answer', lastChangeRef.current)
       setCv(r.cv)
       setAnswersLeft(r.answersLeft)
-      if (r.summary) setToast(r.summary)
+      if (r.summary) { setToast(r.summary); lastChangeRef.current = r.summary }
       setAnswerText('')
       setQIndex((i) => i + 1)
     } catch (e) {
@@ -309,10 +312,10 @@ export default function CvGeneratorTool() {
     setBusy('polish')
     setErr('')
     try {
-      const r = await refineCv(idToken, cv, instruction.trim(), 'polish')
+      const r = await refineCv(idToken, cv, instruction.trim(), 'polish', lastChangeRef.current)
       setCv(r.cv)
       setPolishLeft(r.polishLeft)
-      if (r.summary) setToast(r.summary)
+      if (r.summary) { setToast(r.summary); lastChangeRef.current = r.summary }
       setInstruction('')
     } catch (e) {
       setErr((e as Error).message || s.genErr)
@@ -458,8 +461,8 @@ export default function CvGeneratorTool() {
       )}
 
       {toast && (
-        <div className="fixed top-[4.9rem] left-1/2 -translate-x-1/2 z-[60] max-w-[80vw] inline-flex items-center gap-2 bg-green-600 text-sand-100 px-4 py-2.5 rounded-md shadow-[var(--shadow-md)] text-[0.85rem] animate-[fadeUp_0.3s_ease]" role="status" data-testid="cv-toast">
-          <span aria-hidden="true">✓</span>{toast}
+        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] w-[min(90vw,32rem)] flex items-start gap-2.5 bg-green-600 text-sand-100 px-5 py-3.5 rounded-lg shadow-[var(--shadow-md)] text-[0.92rem] leading-snug animate-[fadeUp_0.3s_ease]" role="status" data-testid="cv-toast">
+          <span aria-hidden="true" className="mt-0.5">✓</span><span>{toast}</span>
         </div>
       )}
 

--- a/src/tools/cv-generator/template.ts
+++ b/src/tools/cv-generator/template.ts
@@ -157,8 +157,10 @@ export function renderCvHtml(cv: Cv, opts: { preview?: boolean } = {}): string {
   if (opts.preview) {
     // Scale the whole A4 page down to the viewport width (never up) so the
     // preview shows the real, uniform proportions of the printed result.
-    const pcss = `html,body{background:#e9ebef;margin:0;padding:0}#cvfit{transform-origin:top center;width:210mm;margin:0 auto}.resume{box-shadow:0 2px 12px rgba(20,30,50,.13)}`
-    const scr = `<script>(function(){function f(){var p=210*96/25.4,el=document.getElementById('cvfit');if(!el)return;var k=Math.min(1,document.documentElement.clientWidth/p);el.style.transform='scale('+k+')';document.body.style.height=(el.scrollHeight*k)+'px'}window.addEventListener('resize',f);window.addEventListener('load',f);document.addEventListener('DOMContentLoaded',f);setTimeout(f,60);setTimeout(f,400)})();<\/script>`
+    // CSS zoom (not transform) so it scales the layout box too — then margin:auto
+    // centres it and there's no stray whitespace beside the page.
+    const pcss = `html,body{background:#e9ebef;margin:0;padding:0}#cvfit{width:210mm;margin:0 auto}.resume{box-shadow:0 2px 12px rgba(20,30,50,.13)}`
+    const scr = `<script>(function(){function f(){var p=210*96/25.4,el=document.getElementById('cvfit');if(!el)return;el.style.zoom=Math.min(1,document.documentElement.clientWidth/p)}window.addEventListener('resize',f);window.addEventListener('load',f);document.addEventListener('DOMContentLoaded',f);setTimeout(f,60);setTimeout(f,400)})();<\/script>`
     return `<!doctype html><html lang="en"><head>${head}<style>${CSS}${pcss}</style></head><body><div id="cvfit">${inner}</div>${scr}</body></html>`
   }
   return `<!doctype html><html lang="en"><head>${head}<style>${CSS}</style></head><body>${inner}</body></html>`


### PR DESCRIPTION
Preview uses CSS zoom (fixes left whitespace); toast centred + wider; refine passes previous-change context so corrections work; prompt enforces recent-first ordering and short skill labels.