### PR TITLE
CV Generator: editable preview → PDF

### DIFF
--- a/src/tools/cv-generator/CvGeneratorTool.tsx
+++ b/src/tools/cv-generator/CvGeneratorTool.tsx
@@ -4,7 +4,7 @@ import { useLocale, localePath } from '../../i18n'
 import { Button, Input, Stack } from '../../components/ui'
 import { DownloadIcon, MicIcon } from '../../components/icons'
 import { loadGis, GOOGLE_CLIENT_ID, decodeJwt, generateCv, refineCv } from '../../lib/cvApi'
-import { renderCvHtml } from './template'
+import { renderCvHtml, renderPrintDoc } from './template'
 import { cvToDocxBlob } from './docx'
 import { cvFilename, type Cv } from './schema'
 
@@ -187,6 +187,7 @@ export default function CvGeneratorTool() {
   const btnRef = useRef<HTMLDivElement>(null)
   const gisRef = useRef<{ renderButton: (el: HTMLElement, o: Record<string, unknown>) => void } | null>(null)
   const activeRef = useRef<HTMLDivElement>(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
   // Guards the auto-generate effect so a failed generation never re-triggers it
   // (which would hammer the API). Reset only when a new file is uploaded.
   const autoTried = useRef(false)
@@ -334,7 +335,13 @@ export default function CvGeneratorTool() {
     if (!cv) return
     const w = window.open('', '_blank')
     if (!w) return
-    w.document.write(renderCvHtml(cv))
+    // Export exactly what the user sees/edited: pull the live (edited) .resume
+    // out of the preview iframe; fall back to a fresh render if unavailable.
+    const edited = iframeRef.current?.contentDocument?.querySelector('.resume') as HTMLElement | null
+    const html = edited
+      ? renderPrintDoc(edited.outerHTML.replace(/ contenteditable="[^"]*"/g, '').replace(/ spellcheck="[^"]*"/g, ''), cvFilename(cv))
+      : renderCvHtml(cv)
+    w.document.write(html)
     w.document.title = cvFilename(cv)
     w.document.close()
     setTimeout(() => { w.focus(); w.print() }, 500)
@@ -411,6 +418,7 @@ export default function CvGeneratorTool() {
           {/* Immersive full-bleed preview, docked flush to the navbar, scaled to fit */}
           <div className="mx-[calc(50%-50vw)] w-screen max-w-[100vw] mt-[calc(clamp(1.5rem,4vw,2.5rem)*-1)]">
             <iframe
+              ref={iframeRef}
               title={cvFilename(cv)}
               className="block w-full h-[calc(100dvh-11rem)] min-h-[22rem] border-0 bg-[#e9ebef]"
               srcDoc={renderCvHtml(cv, { preview: true })}

--- a/src/tools/cv-generator/template.ts
+++ b/src/tools/cv-generator/template.ts
@@ -159,9 +159,20 @@ export function renderCvHtml(cv: Cv, opts: { preview?: boolean } = {}): string {
     // preview shows the real, uniform proportions of the printed result.
     // CSS zoom (not transform) so it scales the layout box too — then margin:auto
     // centres it and there's no stray whitespace beside the page.
-    const pcss = `html,body{background:#e9ebef;margin:0;padding:0}#cvfit{width:210mm;margin:0 auto}.resume{box-shadow:0 2px 12px rgba(20,30,50,.13)}`
+    // The .resume is contenteditable so edits flow straight into the exported PDF.
+    const pcss = `html,body{background:#e9ebef;margin:0;padding:0}#cvfit{width:210mm;margin:0 auto}.resume{box-shadow:0 2px 12px rgba(20,30,50,.13)}[contenteditable]{outline:none}`
+    const editable = inner.replace('<main class="resume">', '<main class="resume" contenteditable="true" spellcheck="false">')
     const scr = `<script>(function(){function f(){var p=210*96/25.4,el=document.getElementById('cvfit');if(!el)return;el.style.zoom=Math.min(1,document.documentElement.clientWidth/p)}window.addEventListener('resize',f);window.addEventListener('load',f);document.addEventListener('DOMContentLoaded',f);setTimeout(f,60);setTimeout(f,400)})();<\/script>`
-    return `<!doctype html><html lang="en"><head>${head}<style>${CSS}${pcss}</style></head><body><div id="cvfit">${inner}</div>${scr}</body></html>`
+    return `<!doctype html><html lang="en"><head>${head}<style>${CSS}${pcss}</style></head><body><div id="cvfit">${editable}</div>${scr}</body></html>`
   }
   return `<!doctype html><html lang="en"><head>${head}<style>${CSS}</style></head><body>${inner}</body></html>`
+}
+
+/** Wrap an already-rendered .resume element's HTML into a print/PDF document
+ *  (A4, no preview scaling) — used to export exactly what the user edited. */
+export function renderPrintDoc(resumeHtml: string, name = 'CV'): string {
+  const head = `<meta charset="utf-8"><title>${esc(name)}</title>`
+    + `<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
+    + `<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">`
+  return `<!doctype html><html lang="en"><head>${head}<style>${CSS}</style></head><body>${resumeHtml}</body></html>`
 }


### PR DESCRIPTION
Preview .resume is contenteditable; PDF export reads the edited HTML from the iframe (renderPrintDoc) so manual edits appear in the PDF.