### PR TITLE
CV Generator: project name style + same-year span

### DIFF
--- a/src/tools/cv-generator/docx.ts
+++ b/src/tools/cv-generator/docx.ts
@@ -122,7 +122,7 @@ function heading(title: string): string {
 }
 
 function dates(a?: string, b?: string): string {
-  if (a && b) return `${a} – ${b}`
+  if (a && b && a !== b) return `${a} – ${b}`
   return a || b || ''
 }
 
@@ -173,7 +173,7 @@ function buildBody(cv: Cv): string {
   if (cv.projects.length) {
     P.push(heading('Projects'))
     for (const pr of cv.projects) {
-      P.push(para(run(pr.name, { b: true, color: INK, sz: 21 }) + run(' — ', { color: INK_SOFT, sz: 21 }) + rich(pr.description, { color: INK_SOFT, sz: 21 }), { after: 20 }))
+      P.push(para(run(pr.name, { color: ACCENT, sz: 21 }) + run(' — ', { color: INK_SOFT, sz: 21 }) + rich(pr.description, { color: INK_SOFT, sz: 21 }), { after: 20 }))
     }
   }
 

--- a/src/tools/cv-generator/template.ts
+++ b/src/tools/cv-generator/template.ts
@@ -59,7 +59,7 @@ const CSS = `
   .project{margin-top:5px;}
   .project:first-of-type{margin-top:0;}
   .proj-line{margin:0;font-size:12px;line-height:1.34;color:var(--ink-soft);}
-  .proj-name{font-weight:700;color:var(--ink);}
+  .proj-name{font-weight:500;color:var(--accent);}
   .row{display:flex;justify-content:space-between;align-items:baseline;gap:14px;margin-top:4px;}
   .row:first-of-type{margin-top:0;}
   .row .deg{font-size:12.5px;font-weight:600;color:var(--ink);}
@@ -92,7 +92,8 @@ function section(title: string, body: string): string {
 }
 
 function dates(a?: string, b?: string): string {
-  if (a && b) return `${esc(a)} – ${esc(b)}`
+  // Collapse an identical span (e.g. 2017–2017) to a single year.
+  if (a && b && a !== b) return `${esc(a)} – ${esc(b)}`
   return esc(a || b || '')
 }
 


### PR DESCRIPTION
Project names use the company-name style (accent, weight 500, not bold); identical year spans collapse to a single year in preview/PDF and .docx.