### PR TITLE
Home: drop card index numbers, promote CV Generator

### DIFF
--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -9,23 +9,21 @@ interface Props {
   index: number
 }
 
-export function ToolCard({ tool, index }: Props) {
+export function ToolCard({ tool }: Props) {
   const { locale, t } = useLocale()
   const l = localizeTool(tool, locale)
-  const num = String(index + 1).padStart(2, '0')
   const comingSoon = tool.status === 'coming-soon'
   const Icon = tool.Icon
 
   const inner = (
     <>
-      <div className="flex items-center justify-between max-[560px]:hidden">
-        <span className="font-mono text-[0.8rem] font-bold text-[color-mix(in_srgb,var(--color-ink)_30%,transparent)] tracking-[0.05em]">{num}</span>
-        {tool.status !== 'stable' && (
+      {tool.status !== 'stable' && (
+        <div className="flex items-center justify-end max-[560px]:hidden">
           <StatusBadge status={tool.status}>
             {comingSoon ? t.card.comingSoon : t.card.beta}
           </StatusBadge>
-        )}
-      </div>
+        </div>
+      )}
 
       <span
         className={`grid place-items-center w-[46px] h-[46px] rounded-[12px] mt-1 transition-[background,color] duration-200 [&_svg]:size-6 max-[560px]:mx-auto max-[560px]:w-[58px] max-[560px]:h-[58px] max-[560px]:rounded-2xl max-[560px]:bg-green-600 max-[560px]:text-sand-100 max-[560px]:shadow-[var(--shadow-sm)] max-[560px]:[&_svg]:w-7 max-[560px]:[&_svg]:h-7 ${

--- a/src/lib/toolSections.ts
+++ b/src/lib/toolSections.ts
@@ -5,7 +5,7 @@ import { categoryLabel, type Locale } from '../i18n'
 // Curated home sections, shared by the HomePage catalog and the AppLauncher so
 // the two stay identical. The first two are hand-picked groupings that cut
 // across the tools' own `category`; the rest fall back to their category order.
-const RECOMMENDED = ['qr-code', 'prayer-times', 'islamic-calendar', 'qibla']
+const RECOMMENDED = ['cv-generator', 'qr-code', 'prayer-times', 'islamic-calendar', 'qibla']
 const DUA = ['istikhara', 'adhkar', 'hisn-al-muslim']
 const CATEGORY_ORDER = ['Saudi / Local', 'Text', 'Converters', 'Calculators', 'Images', 'PDF', 'Files', 'Developer', 'Generators', 'Design', 'Business']
 


### PR DESCRIPTION
Removes the 01/02 index numbers from catalog cards; adds cv-generator to Recommended.