### PR TITLE
Resolve #94, #95, #96

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import { Header } from './Header'
 import { Footer } from './Footer'
 import { LanguageSuggestion } from './LanguageSuggestion'
 import { NotificationBell } from './NotificationBell'
+import { Spinner } from './ui'
 import { UpdatedToast } from './UpdatedToast'
 import { useVersionCheck } from '../lib/useVersionCheck'
 import { clearStaleNotifications } from '../lib/push'
@@ -48,7 +49,7 @@ function LocalizedLayout({ locale }: { locale: Locale }) {
         </a>
         <Header />
         <main id="main" className="flex-1 shrink-0 basis-auto [overflow-x:clip] max-[560px]:pb-[5.5rem]">
-          <Suspense fallback={<div className="wrap py-16 text-ink-faint font-mono">…</div>}>
+          <Suspense fallback={<div className="wrap py-20 flex justify-center"><Spinner /></div>}>
             <Outlet />
           </Suspense>
         </main>

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -299,10 +299,9 @@ export default function BookWithMeTool() {
 
       {/* 1 · Availability painter — no well; big heading; timezone pill + modal */}
       <div className="flex flex-col gap-2.5">
-        <div role="heading" aria-level={2} className={H}>{s.availability}</div>
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-[0.8rem] text-ink-faint">{s.tzShown}</span>
-          <Pill onClick={() => setTzOpen(true)} data-testid="tz-pill" title={s.tzNote(tzLabel(cfg.tz))}><GlobeIcon /> {shortTz(cfg.tz)}</Pill>
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div role="heading" aria-level={2} className={H}>{s.availability}</div>
+          <Pill className="!py-[0.22rem] !px-[0.7rem] !text-[0.74rem]" onClick={() => setTzOpen(true)} data-testid="tz-pill" title={s.tzNote(tzLabel(cfg.tz))}><GlobeIcon /> {shortTz(cfg.tz)}</Pill>
         </div>
         <AvailabilityGrid grid={grid} onChange={updateGrid} locale={locale} />
       </div>

--- a/src/tools/prayer-times/PrayerTimesTool.tsx
+++ b/src/tools/prayer-times/PrayerTimesTool.tsx
@@ -451,9 +451,6 @@ export default function PrayerTimesTool() {
               <li className={`flex items-center gap-[0.8rem] max-[560px]:gap-[0.6rem] py-[0.7rem] px-[0.9rem] max-[560px]:py-[0.55rem] max-[560px]:px-[0.8rem] rounded-md border ${highlight ? 'bg-[color-mix(in_srgb,var(--green-400)_14%,transparent)] border-[color-mix(in_srgb,var(--green-500)_35%,transparent)]' : 'bg-[color-mix(in_srgb,var(--sand-100)_55%,var(--surface))] border-transparent'}`} data-testid={`prow-${it.key}`}>
                 <span className="font-semibold text-[1.05rem] max-[560px]:text-base text-green-700 min-w-[6rem] max-[560px]:min-w-0">{s.prayers[it.key]}</span>
                 <span className="font-mono text-[1.05rem] text-ink ms-auto whitespace-nowrap">{fmtTime(it.time)}</span>
-                {highlight && !active && (
-                  <span className="text-[0.78rem] font-semibold text-green-600 bg-[var(--surface)] border border-[var(--line)] rounded-full py-[0.2rem] px-[0.6rem] whitespace-nowrap max-[560px]:hidden">{s.next} · {s.inTime(countdown.h, countdown.m)}</span>
-                )}
               </li>
             </Fragment>
           )


### PR DESCRIPTION
Global spinner on app load; remove redundant prayer pill; smaller right-aligned tz pill. Closes #94 #95 #96.