### PR TITLE
Fix garbled non-ASCII host names (UTF-8 decode)

### DIFF
--- a/src/lib/bookingApi.ts
+++ b/src/lib/bookingApi.ts
@@ -19,7 +19,10 @@ export function readHostSession(): { name?: string; email?: string; picture?: st
     const hsid = localStorage.getItem('bis-bookwith-hsid')
     if (!hsid) return null
     const b64 = hsid.split('.')[0].replace(/-/g, '+').replace(/_/g, '/')
-    const body = JSON.parse(atob(b64.padEnd(Math.ceil(b64.length / 4) * 4, '=')))
+    const bin = atob(b64.padEnd(Math.ceil(b64.length / 4) * 4, '='))
+    // atob yields a Latin-1 binary string; decode as UTF-8 so non-ASCII names
+    // (e.g. "Björn") aren't mangled.
+    const body = JSON.parse(new TextDecoder().decode(Uint8Array.from(bin, (c) => c.charCodeAt(0))))
     if (body.exp && Date.now() > body.exp) return null
     return { name: body.name, email: body.email, picture: body.picture }
   } catch {

--- a/src/tools/book-with-me/BookWithMeTool.tsx
+++ b/src/tools/book-with-me/BookWithMeTool.tsx
@@ -36,7 +36,9 @@ function readSession(): Session | null {
     const hsid = localStorage.getItem(HSID_KEY)
     if (!hsid) return null
     const b64 = hsid.split('.')[0].replace(/-/g, '+').replace(/_/g, '/')
-    const body = JSON.parse(atob(b64.padEnd(Math.ceil(b64.length / 4) * 4, '=')))
+    const bin = atob(b64.padEnd(Math.ceil(b64.length / 4) * 4, '='))
+    // Decode as UTF-8 (atob gives Latin-1) so names like "Björn" aren't mangled.
+    const body = JSON.parse(new TextDecoder().decode(Uint8Array.from(bin, (c) => c.charCodeAt(0))))
     if (body.exp && Date.now() > body.exp) {
       localStorage.removeItem(HSID_KEY)
       return null


### PR DESCRIPTION
Decode the session JWT payload as UTF-8 so names like Björn aren't mangled.