### PR TITLE
Offload heavy scripts to Web Workers (#154)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,20 @@ declares `@layer theme, base, utilities`.
   (`crypto`, `Intl`, Canvas) over libraries.
 - Keep tools **fully client-side** unless the spec explicitly says `queue`.
 - Match surrounding code style; comments explain *why*, not *what*.
+- **Heavy CPU work runs in a Web Worker, not the main thread** (#154). The
+  pattern: a colocated `<tool>/<x>.worker.ts` (or a shared one in `src/lib/` —
+  `imageEncode.worker.ts` for decode/crop/scale/encode of images,
+  `pdfOps.worker.ts` for pdf-lib pageCount/merge/extract/burst) created with
+  `new Worker(new URL('./x.worker.ts', import.meta.url), { type: 'module' })`,
+  typed request/response messages matched by a request id (stale responses are
+  dropped), `terminate()` on unmount. Pass `File` handles (the read happens in
+  the worker) and use `OffscreenCanvas`/`createImageBitmap` there; transfer big
+  buffers back. `vite.config.ts` sets `worker: { format: 'es' }` — required for
+  workers that lazy-`import()` (e.g. pdf-lib); iife workers can't code-split.
+  *Not* applicable to interactive on-DOM canvases (redact/meme), tiny inputs
+  (ascii's ≤300-char grid, favicon's 8 icons), or GPU-bound `drawImage` work.
+  Functional coverage lives in `e2e/workers.spec.ts` — extend it when you add
+  a worker.
 
 ## Commands
 

--- a/e2e/workers.spec.ts
+++ b/e2e/workers.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+// Functional coverage for the #154 worker offload: each test drives a real file
+// through the tool and asserts the worker-produced output.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAACf0lEQVR4nAXBwQAAIBAAwQMIIIAAAgjgAAIIIICe+wgggAACCCCAAAI4kGZEBCd4IQhRSIIKWShCFZrQhSFMYQlbOMIVnmCCiMM5vCM4oiM51JEdxVEdzdEdwzEdy7Edx3Edz2EOEY/zeE/wRE/yqCd7iqd6mqd7hmd6lmd7jud6nsc8IgEX8IEQiIEU0EAOlEANtEAPjMAMrMAOnMANvIAFRCIu4iMhEiMpopEcKZEaaZEeGZEZWZEdOZEbeRGLiCRcwidCIiZSQhM5URI10RI9MRIzsRI7cRI38RKWEFGc4pWgRCUpqmSlKFVpSleGMpWlbOUoV3mKKSIZl/GZkImZlNFMzpRMzbRMz4zMzKzMzpzMzbyMZUQKruALoRALqaCFXCiFWmiFXhiFWViFXTiFW3gFK4hUXMVXQiVWUkUruVIqtdIqvTIqs7Iqu3Iqt/IqVhFpuIZvhEZspIY2cqM0aqM1emM0ZmM1duM0buM1rCHScR3fCZ3YSR3t5E7p1E7r9M7ozM7q7M7p3M7rWEdk4AZ+EAZxkAY6yIMyqIM26IMxmIM12IMzuIM3sIHIxE38JEziJE10kidlUidt0idjMidrsidncidvYhORhVv4RVjERVroIi/Koi7aoi/GYi7WYi/O4i7ewhYiG7fxm7CJm7TRTd6UTd20Td+Mzdyszd6czd28jW1EDu7gD+EQD+mgh3woh3poh34Yh3lYh304h3t4BzuIXNzFX8IlXtJFL/lSLvXSLv0yLvOyLvtyLvfyLnYRebiHf4RHfKSHPvKjPOqjPfpjPOZjPfbjPO7jPewhYjjDG8GIRjLUyEYxqtGMbgxjGsvYxjGu8QwzPsfjLF9mkRmmAAAAAElFTkSuQmCC',
+  'base64',
+)
+const file = { name: 'tiny.png', mimeType: 'image/png', buffer: PNG }
+
+test('image compressor encodes via the worker', async ({ page }) => {
+  await page.goto('/en/apps/image-compressor')
+  await page.setInputFiles('input[type=file]', file)
+  await expect(page.getByTestId('imgcomp-result')).toBeVisible()
+})
+
+test('format converter converts via the worker', async ({ page }) => {
+  await page.goto('/en/apps/image-format-converter')
+  await page.setInputFiles('input[type=file]', file)
+  await expect(page.getByTestId('ifc-result')).toBeVisible()
+})
+
+test('cropper produces output via the worker', async ({ page }) => {
+  await page.goto('/en/apps/image-cropper')
+  await page.setInputFiles('input[type=file]', file)
+  await expect(page.getByTestId('crop-result')).toBeVisible()
+})
+
+test('steganography hides and reveals via the worker', async ({ page }) => {
+  await page.goto('/en/apps/steganography')
+  await page.setInputFiles('input[type=file]', file)
+  await page.getByTestId('stego-message').fill('hi')
+  const dl = page.waitForEvent('download')
+  await page.getByTestId('stego-embed').click()
+  const download = await dl
+  // saveAs with a .png suffix so the re-upload gets an image/png mime type
+  const path = `${await download.path()}.png`
+  await download.saveAs(path)
+  // round-trip: reveal the message from the downloaded PNG
+  await page.getByTestId('stego-reveal').click()
+  await page.setInputFiles('input[type=file]', path)
+  await expect(page.getByTestId('stego-revealed')).toHaveValue('hi')
+})
+
+test('zip inspector lists entries via the worker', async ({ page }) => {
+  // minimal zip: one stored file "a.txt" containing "hi"
+  const zip = Buffer.from(
+    'UEsDBAoAAAAAAFB381ysKpPYAgAAAAIAAAAFABwAYS50eHRVVAkAA/fJXGr3yVxqdXgLAAEE6AMAAAToAwAAaGlQSwECHgMKAAAAAABQd/NcrCqT2AIAAAACAAAABQAYAAAAAAABAAAAtIEAAAAAYS50eHRVVAUAA/fJXGp1eAsAAQToAwAABOgDAABQSwUGAAAAAAEAAQBLAAAAQQAAAAAA',
+    'base64',
+  )
+  await page.goto('/en/apps/archive-inspector')
+  await page.setInputFiles('input[type=file]', { name: 't.zip', mimeType: 'application/zip', buffer: zip })
+  await expect(page.getByTestId('zip-format')).toHaveText('ZIP')
+  await expect(page.getByTestId('zip-list')).toContainText('a.txt')
+})
+
+test('hash generator hashes a file via the worker', async ({ page }) => {
+  await page.goto('/en/apps/hash-generator')
+  await page.getByTestId('hash-mode-file').click()
+  await page.setInputFiles('input[type=file]', { name: 'abc.txt', mimeType: 'text/plain', buffer: Buffer.from('abc') })
+  await expect(page.getByTestId('hash-hex')).toHaveText('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+})

--- a/e2e/workers.spec.ts
+++ b/e2e/workers.spec.ts
@@ -54,6 +54,40 @@ test('zip inspector lists entries via the worker', async ({ page }) => {
   await expect(page.getByTestId('zip-list')).toContainText('a.txt')
 })
 
+async function makePdf(pages: number): Promise<Buffer> {
+  const { PDFDocument } = await import('pdf-lib')
+  const pdf = await PDFDocument.create()
+  for (let i = 0; i < pages; i++) pdf.addPage([200, 200])
+  return Buffer.from(await pdf.save())
+}
+const asPdf = (name: string, buffer: Buffer) => ({ name, mimeType: 'application/pdf', buffer })
+
+test('pdf merge counts pages and merges via the worker', async ({ page }) => {
+  await page.goto('/en/apps/pdf-merge')
+  await page.setInputFiles('input[type=file]', [asPdf('a.pdf', await makePdf(3)), asPdf('b.pdf', await makePdf(2))])
+  await expect(page.getByTestId('pm-total')).toContainText('5')
+  await page.getByTestId('pm-merge').click()
+  await expect(page.getByTestId('pm-download')).toBeVisible()
+})
+
+test('pdf split extracts a range via the worker', async ({ page }) => {
+  await page.goto('/en/apps/pdf-split')
+  await page.setInputFiles('input[type=file]', asPdf('doc.pdf', await makePdf(3)))
+  await expect(page.getByTestId('ps-count')).toContainText('3')
+  await page.getByTestId('ps-range').fill('2-3')
+  await page.getByTestId('ps-extract').click()
+  await expect(page.getByTestId('ps-download')).toContainText('2')
+})
+
+test('pdf split bursts to single pages via the worker', async ({ page }) => {
+  await page.goto('/en/apps/pdf-split')
+  await page.setInputFiles('input[type=file]', asPdf('doc.pdf', await makePdf(3)))
+  await page.getByTestId('ps-mode-burst').click()
+  await page.getByTestId('ps-split').click()
+  await expect(page.getByTestId('ps-zip')).toBeVisible()
+  await expect(page.getByTestId('ps-page-2')).toBeVisible()
+})
+
 test('hash generator hashes a file via the worker', async ({ page }) => {
   await page.goto('/en/apps/hash-generator')
   await page.getByTestId('hash-mode-file').click()

--- a/src/lib/imageEncode.worker.ts
+++ b/src/lib/imageEncode.worker.ts
@@ -1,0 +1,48 @@
+// Shared image-encode worker (#154). Holds one decoded bitmap and does
+// crop/scale/encode off the main thread — the compressor, format converter and
+// cropper re-encode the full-size image on every slider/drag change, which
+// visibly janked the UI when it ran on the main thread. Driven via ImageEncoder
+// (imageEncoder.ts); one worker instance per tool instance.
+export interface EncodeJob {
+  crop?: { sx: number; sy: number; sw: number; sh: number }
+  maxWidth?: number
+  format: string
+  quality?: number
+  bg?: string // fill behind transparency (JPEG has no alpha)
+}
+export type EncodeRequest =
+  | { id: number; op: 'load'; file: File }
+  | { id: number; op: 'encode'; job: EncodeJob }
+export type EncodeResponse =
+  | { id: number; op: 'load'; width: number; height: number; error?: boolean }
+  | { id: number; op: 'encode'; blob: Blob | null }
+
+let bitmap: ImageBitmap | null = null
+
+self.onmessage = async (e: MessageEvent<EncodeRequest>) => {
+  const req = e.data
+  if (req.op === 'load') {
+    try {
+      bitmap?.close()
+      bitmap = await createImageBitmap(req.file)
+      postMessage({ id: req.id, op: 'load', width: bitmap.width, height: bitmap.height } satisfies EncodeResponse)
+    } catch {
+      bitmap = null
+      postMessage({ id: req.id, op: 'load', width: 0, height: 0, error: true } satisfies EncodeResponse)
+    }
+    return
+  }
+  if (!bitmap) { postMessage({ id: req.id, op: 'encode', blob: null } satisfies EncodeResponse); return }
+  const { crop, maxWidth, format, quality, bg } = req.job
+  const sx = crop?.sx ?? 0, sy = crop?.sy ?? 0
+  const sw = crop?.sw ?? bitmap.width, sh = crop?.sh ?? bitmap.height
+  let ow = sw, oh = sh
+  if (maxWidth && ow > maxWidth) { oh = Math.max(1, Math.round(oh * (maxWidth / ow))); ow = maxWidth }
+  const c = new OffscreenCanvas(Math.max(1, ow), Math.max(1, oh))
+  const ctx = c.getContext('2d')!
+  ctx.imageSmoothingQuality = 'high'
+  if (bg) { ctx.fillStyle = bg; ctx.fillRect(0, 0, c.width, c.height) }
+  ctx.drawImage(bitmap, sx, sy, sw, sh, 0, 0, ow, oh)
+  const blob = await c.convertToBlob({ type: format, quality }).catch(() => null)
+  postMessage({ id: req.id, op: 'encode', blob } satisfies EncodeResponse)
+}

--- a/src/lib/imageEncoder.ts
+++ b/src/lib/imageEncoder.ts
@@ -1,0 +1,41 @@
+// Promise client for imageEncode.worker.ts (#154). Each tool creates one
+// ImageEncoder (= one worker holding that tool's decoded bitmap) and disposes
+// it on unmount. Callers keep their own stale-result guards, same as they did
+// around canvas.toBlob.
+import type { EncodeJob, EncodeRequest, EncodeResponse } from './imageEncode.worker'
+
+export type { EncodeJob }
+
+export class ImageEncoder {
+  private worker: Worker | null = null
+  private seq = 0
+  private pending = new Map<number, (r: EncodeResponse) => void>()
+
+  private post(req: EncodeRequest, resolve: (r: EncodeResponse) => void) {
+    if (!this.worker) {
+      this.worker = new Worker(new URL('./imageEncode.worker.ts', import.meta.url), { type: 'module' })
+      this.worker.onmessage = (e: MessageEvent<EncodeResponse>) => {
+        this.pending.get(e.data.id)?.(e.data)
+        this.pending.delete(e.data.id)
+      }
+    }
+    this.pending.set(req.id, resolve)
+    this.worker.postMessage(req)
+  }
+
+  /** Decode a file into the worker-held bitmap. Resolves null if it can't be decoded. */
+  load(file: File): Promise<{ width: number; height: number } | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'load', file }, (r) =>
+      res(r.op === 'load' && !r.error ? { width: r.width, height: r.height } : null)))
+  }
+
+  /** Crop/scale/encode the loaded bitmap. Resolves null on failure. */
+  encode(job: EncodeJob): Promise<Blob | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'encode', job }, (r) =>
+      res(r.op === 'encode' ? r.blob : null)))
+  }
+
+  dispose() { this.worker?.terminate(); this.worker = null; this.pending.clear() }
+}

--- a/src/lib/pdfOps.ts
+++ b/src/lib/pdfOps.ts
@@ -1,0 +1,46 @@
+// Promise client for pdfOps.worker.ts (#154) — same shape as ImageEncoder:
+// one worker per tool instance, dispose on unmount, null = failed/locked.
+import type { PdfRequest, PdfResponse } from './pdfOps.worker'
+
+export class PdfOps {
+  private worker: Worker | null = null
+  private seq = 0
+  private pending = new Map<number, (r: PdfResponse) => void>()
+
+  private post(req: PdfRequest, resolve: (r: PdfResponse) => void) {
+    if (!this.worker) {
+      this.worker = new Worker(new URL('./pdfOps.worker.ts', import.meta.url), { type: 'module' })
+      this.worker.onmessage = (e: MessageEvent<PdfResponse>) => {
+        this.pending.get(e.data.id)?.(e.data)
+        this.pending.delete(e.data.id)
+      }
+    }
+    this.pending.set(req.id, resolve)
+    this.worker.postMessage(req)
+  }
+
+  /** Page count, or null if the PDF is locked/unreadable. */
+  pageCount(file: File): Promise<number | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'pageCount', file }, (r) => res(r.op === 'pageCount' ? r.pages : null)))
+  }
+
+  merge(files: File[]): Promise<Blob | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'merge', files }, (r) => res(r.op === 'merge' ? r.blob : null)))
+  }
+
+  /** Extract the given 0-based page indices into a new PDF. */
+  extract(file: File, indices: number[]): Promise<Blob | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'extract', file, indices }, (r) => res(r.op === 'extract' ? r.blob : null)))
+  }
+
+  /** Split into one PDF per page; resolves the raw bytes per page. */
+  burst(file: File): Promise<ArrayBuffer[] | null> {
+    const id = ++this.seq
+    return new Promise((res) => this.post({ id, op: 'burst', file }, (r) => res(r.op === 'burst' ? r.pages : null)))
+  }
+
+  dispose() { this.worker?.terminate(); this.worker = null; this.pending.clear() }
+}

--- a/src/lib/pdfOps.worker.ts
+++ b/src/lib/pdfOps.worker.ts
@@ -1,0 +1,59 @@
+// pdf-lib operations off the main thread (#154). pdf-lib's load/copy/save are
+// pure-JS CPU work that used to run on the UI thread; here they run in a
+// worker, with pdf-lib lazy-loaded into the worker bundle on first use.
+// Driven via PdfOps (pdfOps.ts); one worker instance per tool instance.
+export type PdfRequest =
+  | { id: number; op: 'pageCount'; file: File }
+  | { id: number; op: 'merge'; files: File[] }
+  | { id: number; op: 'extract'; file: File; indices: number[] }
+  | { id: number; op: 'burst'; file: File }
+export type PdfResponse =
+  | { id: number; op: 'pageCount'; pages: number | null }
+  | { id: number; op: 'merge'; blob: Blob | null }
+  | { id: number; op: 'extract'; blob: Blob | null }
+  | { id: number; op: 'burst'; pages: ArrayBuffer[] | null }
+
+let lib: typeof import('pdf-lib') | null = null
+const pdf = async () => (lib ??= await import('pdf-lib'))
+
+const asPdfBlob = (bytes: Uint8Array) => new Blob([bytes as unknown as BlobPart], { type: 'application/pdf' })
+
+self.onmessage = async (e: MessageEvent<PdfRequest>) => {
+  const req = e.data
+  try {
+    const { PDFDocument } = await pdf()
+    if (req.op === 'pageCount') {
+      const doc = await PDFDocument.load(await req.file.arrayBuffer())
+      postMessage({ id: req.id, op: 'pageCount', pages: doc.getPageCount() } satisfies PdfResponse)
+    } else if (req.op === 'merge') {
+      const merged = await PDFDocument.create()
+      for (const f of req.files) {
+        const src = await PDFDocument.load(await f.arrayBuffer())
+        const pages = await merged.copyPages(src, src.getPageIndices())
+        pages.forEach((p) => merged.addPage(p))
+      }
+      postMessage({ id: req.id, op: 'merge', blob: asPdfBlob(await merged.save()) } satisfies PdfResponse)
+    } else if (req.op === 'extract') {
+      const doc = await PDFDocument.load(await req.file.arrayBuffer())
+      const out = await PDFDocument.create()
+      const copied = await out.copyPages(doc, req.indices)
+      copied.forEach((p) => out.addPage(p))
+      postMessage({ id: req.id, op: 'extract', blob: asPdfBlob(await out.save()) } satisfies PdfResponse)
+    } else {
+      const doc = await PDFDocument.load(await req.file.arrayBuffer())
+      const pages: ArrayBuffer[] = []
+      for (let i = 0; i < doc.getPageCount(); i++) {
+        const out = await PDFDocument.create()
+        const [p] = await out.copyPages(doc, [i])
+        out.addPage(p)
+        const bytes = await out.save()
+        pages.push(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer)
+      }
+      // transfer the page buffers — no copy back to the main thread
+      ;(postMessage as (m: PdfResponse, t: Transferable[]) => void)({ id: req.id, op: 'burst', pages }, pages)
+    }
+  } catch {
+    const nulls = { pageCount: { pages: null }, merge: { blob: null }, extract: { blob: null }, burst: { pages: null } } as const
+    postMessage({ id: req.id, op: req.op, ...nulls[req.op] } as PdfResponse)
+  }
+}

--- a/src/tools/hash-generator/HashGeneratorTool.tsx
+++ b/src/tools/hash-generator/HashGeneratorTool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { CopyIcon, UploadIcon } from '../../components/icons'
 import { Button, Textarea, Stack, Seg, SegButton } from '../../components/ui'
+import type { HashRequest, HashResponse } from './hash.worker'
 
 type Algo = 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'
 const ALGOS: Algo[] = ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512']
@@ -25,37 +26,41 @@ const STR = {
   },
 }
 
-const toHex = (buf: ArrayBuffer) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('')
-const toB64 = (buf: ArrayBuffer) => btoa(String.fromCharCode(...new Uint8Array(buf)))
-
 export default function HashGeneratorTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const [mode, setMode] = useState<'text' | 'file'>('text')
   const [text, setText] = useState('')
-  const [file, setFile] = useState<{ name: string; buf: ArrayBuffer } | null>(null)
+  const [file, setFile] = useState<File | null>(null)
   const [algo, setAlgo] = useState<Algo>('SHA-256')
   const [hex, setHex] = useState('')
   const [b64, setB64] = useState('')
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const reqRef = useRef(0)
+
+  useEffect(() => () => { workerRef.current?.terminate() }, [])
 
   useEffect(() => {
-    let cancelled = false
-    const data: BufferSource | null | undefined = mode === 'file' ? file?.buf : (text ? new TextEncoder().encode(text) : null)
+    const data: File | string | null = mode === 'file' ? file : (text || null)
     if (!data) { setHex(''); setB64(''); return }
+    workerRef.current ??= new Worker(new URL('./hash.worker.ts', import.meta.url), { type: 'module' })
+    const worker = workerRef.current
+    const id = ++reqRef.current
     setBusy(true)
-    crypto.subtle.digest(algo, data).then((d) => {
-      if (cancelled) return
-      setHex(toHex(d)); setB64(toB64(d)); setBusy(false)
-    })
-    return () => { cancelled = true }
+    const onMessage = (e: MessageEvent<HashResponse>) => {
+      if (e.data.id !== reqRef.current) return // stale response — a newer request is in flight
+      setHex(e.data.hex); setB64(e.data.b64); setBusy(false)
+    }
+    worker.addEventListener('message', onMessage)
+    worker.postMessage({ id, algo, data } satisfies HashRequest)
+    return () => worker.removeEventListener('message', onMessage)
   }, [mode, text, file, algo])
 
-  async function onFile(f: File | undefined) {
-    if (!f) return
-    setFile({ name: f.name, buf: await f.arrayBuffer() })
+  function onFile(f: File | undefined) {
+    if (f) setFile(f)
   }
 
   async function copy(value: string, which: string) {
@@ -90,7 +95,7 @@ export default function HashGeneratorTool() {
           onDragOver={(e) => e.preventDefault()} onDrop={(e) => { e.preventDefault(); onFile(e.dataTransfer.files[0]) }}>
           <UploadIcon />
           <span>{file ? file.name : s.drop}</span>
-          {file && <small>{s.bytes(file.buf.byteLength)}</small>}
+          {file && <small>{s.bytes(file.size)}</small>}
           <input ref={fileRef} type="file" className="absolute w-px h-px opacity-0" onChange={(e) => onFile(e.target.files?.[0])} />
         </button>
       )}

--- a/src/tools/hash-generator/hash.worker.ts
+++ b/src/tools/hash-generator/hash.worker.ts
@@ -1,0 +1,20 @@
+// Hashing runs in a Worker so large files never block the UI thread (#154).
+// Files are passed as handles and read here; text is encoded here too.
+export interface HashRequest { id: number; algo: string; data: File | string }
+export interface HashResponse { id: number; hex: string; b64: string; error?: boolean }
+
+self.onmessage = async (e: MessageEvent<HashRequest>) => {
+  const { id, algo, data } = e.data
+  try {
+    const bytes = typeof data === 'string'
+      ? new TextEncoder().encode(data)
+      : new Uint8Array(await data.arrayBuffer())
+    const digest = new Uint8Array(await crypto.subtle.digest(algo, bytes))
+    const hex = [...digest].map((b) => b.toString(16).padStart(2, '0')).join('')
+    let bin = ''
+    for (const b of digest) bin += String.fromCharCode(b)
+    postMessage({ id, hex, b64: btoa(bin) } satisfies HashResponse)
+  } catch {
+    postMessage({ id, hex: '', b64: '', error: true } satisfies HashResponse)
+  }
+}

--- a/src/tools/image-compressor/ImageCompressorTool.tsx
+++ b/src/tools/image-compressor/ImageCompressorTool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Button, Input, Field, Stack, Seg, SegButton } from '../../components/ui'
+import { ImageEncoder } from '../../lib/imageEncoder'
 
 type Fmt = 'image/jpeg' | 'image/webp' | 'image/png'
 
@@ -26,31 +27,34 @@ export default function ImageCompressorTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const fileRef = useRef<HTMLInputElement>(null)
-  const [src, setSrc] = useState<{ name: string; size: number; bitmap: ImageBitmap } | null>(null)
+  const [src, setSrc] = useState<{ name: string; size: number; width: number } | null>(null)
   const [quality, setQuality] = useState(0.8)
   const [format, setFormat] = useState<Fmt>('image/jpeg')
   const [maxW, setMaxW] = useState('')
   const [busy, setBusy] = useState(false)
   const [out, setOut] = useState<{ url: string; size: number } | null>(null)
+  const encRef = useRef<ImageEncoder | null>(null)
+
+  useEffect(() => () => encRef.current?.dispose(), [])
 
   async function onFile(f: File | undefined) {
     if (!f || !f.type.startsWith('image/')) return
-    try { const bitmap = await createImageBitmap(f); setSrc({ name: f.name.replace(/\.[^.]+$/, ''), size: f.size, bitmap }) } catch { /* ignore */ }
+    encRef.current ??= new ImageEncoder()
+    const dim = await encRef.current.load(f)
+    if (dim) setSrc({ name: f.name.replace(/\.[^.]+$/, ''), size: f.size, width: dim.width })
   }
 
+  // Re-encode in the worker (#154) — big images no longer jank the sliders.
   useEffect(() => {
     if (!src) return
     let cancelled = false
     setBusy(true)
-    const scale = maxW && src.bitmap.width > +maxW ? +maxW / src.bitmap.width : 1
-    const w = Math.round(src.bitmap.width * scale), h = Math.round(src.bitmap.height * scale)
-    const c = document.createElement('canvas'); c.width = w; c.height = h
-    c.getContext('2d')!.drawImage(src.bitmap, 0, 0, w, h)
-    c.toBlob((blob) => {
-      if (cancelled || !blob) { setBusy(false); return }
-      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
+    encRef.current!.encode({ maxWidth: maxW ? +maxW : undefined, format, quality: format === 'image/png' ? undefined : quality }).then((blob) => {
+      if (cancelled) return
       setBusy(false)
-    }, format, format === 'image/png' ? undefined : quality)
+      if (!blob) return
+      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
+    })
     return () => { cancelled = true }
   }, [src, quality, format, maxW])
 
@@ -80,7 +84,7 @@ export default function ImageCompressorTool() {
                 disabled={format === 'image/png'} onChange={(e) => setQuality(+e.target.value)} />
             </Field>
             <Field label={s.maxW}>
-              <Input className="font-mono" type="number" min={1} placeholder={String(src.bitmap.width)} value={maxW} data-testid="imgcomp-maxw" onChange={(e) => setMaxW(e.target.value)} />
+              <Input className="font-mono" type="number" min={1} placeholder={String(src.width)} value={maxW} data-testid="imgcomp-maxw" onChange={(e) => setMaxW(e.target.value)} />
             </Field>
           </div>
 

--- a/src/tools/image-cropper/ImageCropperTool.tsx
+++ b/src/tools/image-cropper/ImageCropperTool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Button, Field, Stack, Seg, SegButton } from '../../components/ui'
+import { ImageEncoder } from '../../lib/imageEncoder'
 
 type Fmt = 'image/png' | 'image/jpeg' | 'image/webp'
 type Handle = 'nw' | 'ne' | 'sw' | 'se'
@@ -20,7 +21,7 @@ export default function ImageCropperTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const fileRef = useRef<HTMLInputElement>(null)
-  const [src, setSrc] = useState<{ name: string; url: string; bitmap: ImageBitmap; dw: number; dh: number; scale: number } | null>(null)
+  const [src, setSrc] = useState<{ name: string; url: string; dw: number; dh: number; scale: number } | null>(null)
   const [rect, setRect] = useState<Rect>({ x: 0, y: 0, w: 0, h: 0 })
   const [ratio, setRatio] = useState<number | null>(null)
   const [format, setFormat] = useState<Fmt>('image/png')
@@ -28,18 +29,21 @@ export default function ImageCropperTool() {
   const [out, setOut] = useState<{ url: string; size: number; w: number; h: number } | null>(null)
   const drag = useRef<{ mode: 'move' | Handle; sx: number; sy: number; start: Rect } | null>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
+  const encRef = useRef<ImageEncoder | null>(null)
+
+  useEffect(() => () => encRef.current?.dispose(), [])
 
   async function onFile(f: File | undefined) {
     if (!f || !f.type.startsWith('image/')) return
-    try {
-      const bitmap = await createImageBitmap(f)
-      const scale = Math.min(1, MAXW / bitmap.width)
-      const dw = Math.round(bitmap.width * scale), dh = Math.round(bitmap.height * scale)
-      setSrc({ name: f.name.replace(/\.[^.]+$/, ''), url: URL.createObjectURL(f), bitmap, dw, dh, scale })
-      const w = Math.round(dw * 0.7), h = Math.round(dh * 0.7)
-      setRect({ x: Math.round((dw - w) / 2), y: Math.round((dh - h) / 2), w, h })
-      setRatio(null)
-    } catch { /* ignore */ }
+    encRef.current ??= new ImageEncoder()
+    const dim = await encRef.current.load(f)
+    if (!dim) return
+    const scale = Math.min(1, MAXW / dim.width)
+    const dw = Math.round(dim.width * scale), dh = Math.round(dim.height * scale)
+    setSrc({ name: f.name.replace(/\.[^.]+$/, ''), url: URL.createObjectURL(f), dw, dh, scale })
+    const w = Math.round(dw * 0.7), h = Math.round(dh * 0.7)
+    setRect({ x: Math.round((dw - w) / 2), y: Math.round((dh - h) / 2), w, h })
+    setRatio(null)
   }
 
   // Apply an aspect ratio to a rect (adjust height from width), clamped to bounds.
@@ -85,17 +89,18 @@ export default function ImageCropperTool() {
   function endDrag() { drag.current = null }
 
   // Render the cropped region at full resolution whenever the rect/format changes.
-  // The cancel guard ensures a late toBlob from a prior state can't overwrite the latest.
+  // The encode runs in a worker (#154) — dragging the crop box used to re-encode a
+  // full-res crop on the main thread on every pointer move. The cancel guard
+  // ensures a late result from a prior state can't overwrite the latest.
   useEffect(() => {
     if (!src || rect.w < 1) return
     let cancelled = false
     const sx = Math.round(rect.x / src.scale), sy = Math.round(rect.y / src.scale)
     const sw = Math.max(1, Math.round(rect.w / src.scale)), sh = Math.max(1, Math.round(rect.h / src.scale))
-    const c = document.createElement('canvas'); c.width = sw; c.height = sh
-    const ctx = c.getContext('2d')!
-    if (format === 'image/jpeg') { ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, sw, sh) }
-    ctx.drawImage(src.bitmap, sx, sy, sw, sh, 0, 0, sw, sh)
-    c.toBlob((blob) => { if (cancelled || !blob) return; setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size, w: sw, h: sh } }) }, format, format === 'image/png' ? undefined : quality)
+    encRef.current!.encode({ crop: { sx, sy, sw, sh }, format, quality: format === 'image/png' ? undefined : quality, bg: format === 'image/jpeg' ? '#fff' : undefined }).then((blob) => {
+      if (cancelled || !blob) return
+      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size, w: sw, h: sh } })
+    })
     return () => { cancelled = true }
   }, [rect, format, quality, src])
 

--- a/src/tools/image-format-converter/ImageFormatConverterTool.tsx
+++ b/src/tools/image-format-converter/ImageFormatConverterTool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Button, Field, Stack, Seg, SegButton } from '../../components/ui'
+import { ImageEncoder } from '../../lib/imageEncoder'
 
 type Fmt = 'image/png' | 'image/jpeg' | 'image/webp'
 
@@ -30,36 +31,36 @@ export default function ImageFormatConverterTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const fileRef = useRef<HTMLInputElement>(null)
-  const [src, setSrc] = useState<{ name: string; size: number; type: string; bitmap: ImageBitmap } | null>(null)
+  const [src, setSrc] = useState<{ name: string; size: number; type: string } | null>(null)
   const [target, setTarget] = useState<Fmt>('image/jpeg')
   const [quality, setQuality] = useState(0.92)
   const [bg, setBg] = useState('#ffffff')
   const [busy, setBusy] = useState(false)
   const [out, setOut] = useState<{ url: string; size: number } | null>(null)
+  const encRef = useRef<ImageEncoder | null>(null)
+
+  useEffect(() => () => encRef.current?.dispose(), [])
 
   async function onFile(f: File | undefined) {
     if (!f || !f.type.startsWith('image/')) return
-    try {
-      const bitmap = await createImageBitmap(f)
-      setSrc({ name: f.name.replace(/\.[^.]+$/, ''), size: f.size, type: f.type, bitmap })
-      setTarget(f.type === 'image/jpeg' ? 'image/png' : 'image/jpeg')
-    } catch { /* ignore */ }
+    encRef.current ??= new ImageEncoder()
+    const dim = await encRef.current.load(f)
+    if (!dim) return
+    setSrc({ name: f.name.replace(/\.[^.]+$/, ''), size: f.size, type: f.type })
+    setTarget(f.type === 'image/jpeg' ? 'image/png' : 'image/jpeg')
   }
 
+  // Conversion runs in the worker (#154) so full-size re-encodes never jank the UI.
   useEffect(() => {
     if (!src) return
     let cancelled = false
     setBusy(true)
-    const c = document.createElement('canvas')
-    c.width = src.bitmap.width; c.height = src.bitmap.height
-    const ctx = c.getContext('2d')!
-    if (target === 'image/jpeg') { ctx.fillStyle = bg; ctx.fillRect(0, 0, c.width, c.height) }
-    ctx.drawImage(src.bitmap, 0, 0)
-    c.toBlob((blob) => {
-      if (cancelled || !blob) { setBusy(false); return }
-      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
+    encRef.current!.encode({ format: target, quality: target === 'image/png' ? undefined : quality, bg: target === 'image/jpeg' ? bg : undefined }).then((blob) => {
+      if (cancelled) return
       setBusy(false)
-    }, target, target === 'image/png' ? undefined : quality)
+      if (!blob) return
+      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
+    })
     return () => { cancelled = true }
   }, [src, target, quality, bg])
 

--- a/src/tools/pdf-edit/PdfEditTool.tsx
+++ b/src/tools/pdf-edit/PdfEditTool.tsx
@@ -4,6 +4,7 @@ import { UploadIcon, DownloadIcon, InfoIcon, TrashIcon } from '../../components/
 import { Stack, Button, Spinner } from '../../components/ui'
 import type { RenderedPage } from '../../lib/pdfRender'
 import type { PageContent, EditObject, ImgXf } from './contentStream'
+import type { EditResponse } from './edit.worker'
 
 type TextBox = { id: string; page: number; x: number; y: number; w: number; h: number; text: string; size: number }
 const HANDLES = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'] as const
@@ -51,6 +52,8 @@ export default function PdfEditTool() {
   const [out, setOut] = useState<{ url: string; size: number } | null>(null)
   const lastSize = useRef(14)
   const pageBoxRef = useRef<HTMLDivElement>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const reqRef = useRef(0)
   const [boxH, setBoxH] = useState(0)
   const pageImgRef = useRef<HTMLImageElement>(null)
   const clips = useRef<Map<string, string>>(new Map())
@@ -62,13 +65,42 @@ export default function PdfEditTool() {
     return { nx: (e.clientX - r.left) / r.width, ny: (e.clientY - r.top) / r.height }
   }
 
+  // Content-stream parsing + the final rebuild run in edit.worker.ts (#154).
+  function editWorker(): Worker {
+    workerRef.current ??= new Worker(new URL('./edit.worker.ts', import.meta.url), { type: 'module' })
+    return workerRef.current
+  }
+  function workerCall(req:
+    | { op: 'load'; buf: ArrayBuffer }
+    | { op: 'save'; file: File; pc: PageContent[]; deleted: Set<string>; xf: Map<string, ImgXf>; texts: TextBox[] },
+  ): Promise<EditResponse> {
+    const worker = editWorker()
+    const id = ++reqRef.current
+    return new Promise((resolve) => {
+      const onMessage = (e: MessageEvent<EditResponse>) => {
+        if (e.data.id !== id) return
+        worker.removeEventListener('message', onMessage)
+        resolve(e.data)
+      }
+      worker.addEventListener('message', onMessage)
+      worker.postMessage({ ...req, id })
+    })
+  }
+
+  useEffect(() => () => { workerRef.current?.terminate() }, [])
+
   async function onFile(f: File | null | undefined) {
     if (!f || !(f.type === 'application/pdf' || f.name.toLowerCase().endsWith('.pdf'))) return
     setBusy(true); setErr(''); setOut(null); setDeleted(new Set()); setXf(new Map()); setTexts([]); setSel(null); setPi(0); clips.current = new Map()
     try {
-      const [{ renderPdf }, { loadEditable }] = await Promise.all([import('../../lib/pdfRender'), import('./contentStream')])
-      const [rendered, editable] = await Promise.all([renderPdf(await f.arrayBuffer(), 2, true), loadEditable(await f.arrayBuffer())])
-      setFile(f); setPages(rendered); setPc(editable.pages); covers.current = new Map()
+      const { renderPdf } = await import('../../lib/pdfRender')
+      const [rendered, loaded] = await Promise.all([
+        renderPdf(await f.arrayBuffer(), 2, true),
+        workerCall({ op: 'load', buf: await f.arrayBuffer() }),
+      ])
+      const pcPages = loaded.op === 'load' ? loaded.pages : null
+      if (!pcPages) throw new Error('unreadable')
+      setFile(f); setPages(rendered); setPc(pcPages); covers.current = new Map()
     } catch {
       setErr(s.locked); setFile(null); setPages(null); setPc(null)
     } finally { setBusy(false) }
@@ -281,31 +313,12 @@ export default function PdfEditTool() {
     if (out) { saveBlob(out.url); return } // already built — just download again
     setBusy(true); setErr('')
     try {
-      const { PDFDocument, StandardFonts, rgb } = await import('pdf-lib')
-      const { applyEdits, writePage } = await import('./contentStream')
-      const pdf = await PDFDocument.load(await file.arrayBuffer())
-      for (const page of pc) {
-        const hasEdit = page.objects.some((o) => deleted.has(o.id) || xf.has(o.id))
-        if (hasEdit) writePage(pdf, page.page, applyEdits(page, deleted, xf))
-      }
-      if (texts.some((t) => t.text.trim())) {
-        const font = await pdf.embedFont(StandardFonts.Helvetica)
-        const pgs = pdf.getPages()
-        for (const t of texts) {
-          const page = pgs[t.page]; if (!page || !t.text.trim()) continue
-          const W = page.getWidth(), H = page.getHeight()
-          // eslint-disable-next-line no-control-regex
-          const safe = t.text.replace(/[^\x00-\xFF]/g, '')
-          page.drawText(safe, { x: t.x * W, y: H - t.y * H - t.size, size: t.size, font, color: rgb(0.05, 0.05, 0.05), maxWidth: t.w * W, lineHeight: t.size * 1.2 })
-        }
-      }
-      const bytes = await pdf.save()
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' })
+      const res = await workerCall({ op: 'save', file, pc, deleted, xf, texts })
+      const blob = res.op === 'save' ? res.blob : null
+      if (!blob) { setErr(s.locked); return }
       const url = URL.createObjectURL(blob)
       setOut((p) => { if (p) URL.revokeObjectURL(p.url); return { url, size: blob.size } })
       saveBlob(url) // download in the same click
-    } catch {
-      setErr(s.locked)
     } finally { setBusy(false) }
   }
 

--- a/src/tools/pdf-edit/edit.worker.ts
+++ b/src/tools/pdf-edit/edit.worker.ts
@@ -1,0 +1,48 @@
+// PDF Edit's heavy pdf-lib work runs here off the main thread (#154):
+// 'load' parses the content streams (loadEditable), 'save' rebuilds the PDF
+// with edits + added text. PageContent/Set/Map all survive structured clone.
+import type { PageContent, ImgXf } from './contentStream'
+
+export interface EditText { page: number; x: number; y: number; w: number; size: number; text: string }
+export type EditRequest =
+  | { id: number; op: 'load'; buf: ArrayBuffer }
+  | { id: number; op: 'save'; file: File; pc: PageContent[]; deleted: Set<string>; xf: Map<string, ImgXf>; texts: EditText[] }
+export type EditResponse =
+  | { id: number; op: 'load'; pages: PageContent[] | null }
+  | { id: number; op: 'save'; blob: Blob | null }
+
+self.onmessage = async (e: MessageEvent<EditRequest>) => {
+  const req = e.data
+  try {
+    if (req.op === 'load') {
+      const { loadEditable } = await import('./contentStream')
+      const { pages } = await loadEditable(req.buf)
+      postMessage({ id: req.id, op: 'load', pages } satisfies EditResponse)
+      return
+    }
+    const { PDFDocument, StandardFonts, rgb } = await import('pdf-lib')
+    const { applyEdits, writePage } = await import('./contentStream')
+    const pdf = await PDFDocument.load(await req.file.arrayBuffer())
+    for (const page of req.pc) {
+      const hasEdit = page.objects.some((o) => req.deleted.has(o.id) || req.xf.has(o.id))
+      if (hasEdit) writePage(pdf, page.page, applyEdits(page, req.deleted, req.xf))
+    }
+    if (req.texts.some((t) => t.text.trim())) {
+      const font = await pdf.embedFont(StandardFonts.Helvetica)
+      const pgs = pdf.getPages()
+      for (const t of req.texts) {
+        const page = pgs[t.page]; if (!page || !t.text.trim()) continue
+        const W = page.getWidth(), H = page.getHeight()
+        // eslint-disable-next-line no-control-regex
+        const safe = t.text.replace(/[^\x00-\xFF]/g, '')
+        page.drawText(safe, { x: t.x * W, y: H - t.y * H - t.size, size: t.size, font, color: rgb(0.05, 0.05, 0.05), maxWidth: t.w * W, lineHeight: t.size * 1.2 })
+      }
+    }
+    const bytes = await pdf.save()
+    postMessage({ id: req.id, op: 'save', blob: new Blob([bytes as unknown as BlobPart], { type: 'application/pdf' }) } satisfies EditResponse)
+  } catch {
+    postMessage(req.op === 'load'
+      ? ({ id: req.id, op: 'load', pages: null } satisfies EditResponse)
+      : ({ id: req.id, op: 'save', blob: null } satisfies EditResponse))
+  }
+}

--- a/src/tools/pdf-merge/PdfMergeTool.tsx
+++ b/src/tools/pdf-merge/PdfMergeTool.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Stack, Button } from '../../components/ui'
+import { PdfOps } from '../../lib/pdfOps'
 
 interface Item { id: string; file: File; pages: number | null; error?: boolean }
 
@@ -29,22 +30,21 @@ export default function PdfMergeTool() {
   const [items, setItems] = useState<Item[]>([])
   const [busy, setBusy] = useState(false)
   const [out, setOut] = useState<{ url: string; size: number } | null>(null)
+  const opsRef = useRef<PdfOps | null>(null)
 
+  useEffect(() => () => opsRef.current?.dispose(), [])
+
+  // Page counting + merging run in a worker (#154) — big PDFs never jank the UI.
   async function addFiles(files: FileList | null) {
     if (!files) return
     const pdfs = [...files].filter((f) => f.type === 'application/pdf' || f.name.toLowerCase().endsWith('.pdf'))
     if (!pdfs.length) return
     const fresh: Item[] = pdfs.map((f) => ({ id: `p${uid++}`, file: f, pages: null }))
     setItems((cur) => [...cur, ...fresh]); setOut(null)
-    const { PDFDocument } = await import('pdf-lib')
+    opsRef.current ??= new PdfOps()
     for (const it of fresh) {
-      try {
-        const doc = await PDFDocument.load(await it.file.arrayBuffer())
-        const n = doc.getPageCount()
-        setItems((cur) => cur.map((x) => x.id === it.id ? { ...x, pages: n } : x))
-      } catch {
-        setItems((cur) => cur.map((x) => x.id === it.id ? { ...x, pages: 0, error: true } : x))
-      }
+      const n = await opsRef.current.pageCount(it.file)
+      setItems((cur) => cur.map((x) => x.id === it.id ? (n === null ? { ...x, pages: 0, error: true } : { ...x, pages: n }) : x))
     }
   }
   function move(i: number, d: -1 | 1) {
@@ -59,16 +59,9 @@ export default function PdfMergeTool() {
     if (!items.length || anyLocked) return
     setBusy(true)
     try {
-      const { PDFDocument } = await import('pdf-lib')
-      const merged = await PDFDocument.create()
-      for (const it of items) {
-        const src = await PDFDocument.load(await it.file.arrayBuffer())
-        const pages = await merged.copyPages(src, src.getPageIndices())
-        pages.forEach((p) => merged.addPage(p))
-      }
-      const bytes = await merged.save()
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' })
-      setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
+      opsRef.current ??= new PdfOps()
+      const blob = await opsRef.current.merge(items.map((it) => it.file))
+      if (blob) setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
     } finally { setBusy(false) }
   }
 

--- a/src/tools/pdf-sign/PdfSignTool.tsx
+++ b/src/tools/pdf-sign/PdfSignTool.tsx
@@ -4,6 +4,7 @@ import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Stack, Button, Spinner } from '../../components/ui'
 import type { RenderedPage } from '../../lib/pdfRender'
 import SignaturePad from './SignaturePad'
+import type { SignRequest, SignResponse } from './sign.worker'
 
 type Sig = { url: string; w: number; h: number }
 type Placement = { id: string; page: number; x: number; y: number; w: number } // x,y,w normalised
@@ -55,6 +56,10 @@ export default function PdfSignTool() {
   const imgRef = useRef<HTMLImageElement>(null)
   const loupeRef = useRef<HTMLCanvasElement>(null)
   const [loupe, setLoupe] = useState<{ x: number; y: number } | null>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const reqRef = useRef(0)
+
+  useEffect(() => () => { workerRef.current?.terminate() }, [])
 
   // Restore a previously drawn signature.
   useEffect(() => {
@@ -191,26 +196,26 @@ export default function PdfSignTool() {
     setLoupe({ x: clientX, y: clientY })
   }
 
-  async function download() {
+  // Stamping runs in a worker (#154) so signing a big PDF never freezes the page.
+  function download() {
     if (!file || !sig || !placements.length) return
     setBusy(true); setErr('')
-    try {
-      const { PDFDocument } = await import('pdf-lib')
-      const pdf = await PDFDocument.load(await file.arrayBuffer())
-      const png = await pdf.embedPng(sig.url)
-      const pgs = pdf.getPages()
-      for (const pl of placements) {
-        const page = pgs[pl.page]; if (!page) continue
-        const W = page.getWidth(), H = page.getHeight()
-        const w = pl.w * W, h = w * (sig.h / sig.w)
-        page.drawImage(png, { x: pl.x * W, y: H - pl.y * H - h, width: w, height: h })
-      }
-      const bytes = await pdf.save()
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' })
+    workerRef.current ??= new Worker(new URL('./sign.worker.ts', import.meta.url), { type: 'module' })
+    const worker = workerRef.current
+    const id = ++reqRef.current
+    const onMessage = (e: MessageEvent<SignResponse>) => {
+      if (e.data.id !== reqRef.current) return
+      worker.removeEventListener('message', onMessage)
+      setBusy(false)
+      if (!e.data.blob) { setErr(s.locked); return }
+      const blob = e.data.blob
       setOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size } })
-    } catch {
-      setErr(s.locked)
-    } finally { setBusy(false) }
+    }
+    worker.addEventListener('message', onMessage)
+    worker.postMessage({
+      id, file, png: sig.url, sigRatio: sig.h / sig.w,
+      placements: placements.map(({ page, x, y, w }) => ({ page, x, y, w })),
+    } satisfies SignRequest)
   }
 
   const pagePlacements = placements.filter((p) => p.page === pi)

--- a/src/tools/pdf-sign/sign.worker.ts
+++ b/src/tools/pdf-sign/sign.worker.ts
@@ -1,0 +1,25 @@
+// Stamping the signature into the PDF runs here off the main thread (#154):
+// pdf-lib load + embedPng + save is pure-JS CPU work that scales with PDF size.
+export interface SignPlacement { page: number; x: number; y: number; w: number }
+export interface SignRequest { id: number; file: File; png: string; sigRatio: number; placements: SignPlacement[] }
+export interface SignResponse { id: number; blob: Blob | null }
+
+self.onmessage = async (e: MessageEvent<SignRequest>) => {
+  const { id, file, png, sigRatio, placements } = e.data
+  try {
+    const { PDFDocument } = await import('pdf-lib')
+    const pdf = await PDFDocument.load(await file.arrayBuffer())
+    const embedded = await pdf.embedPng(png)
+    const pgs = pdf.getPages()
+    for (const pl of placements) {
+      const page = pgs[pl.page]; if (!page) continue
+      const W = page.getWidth(), H = page.getHeight()
+      const w = pl.w * W, h = w * sigRatio
+      page.drawImage(embedded, { x: pl.x * W, y: H - pl.y * H - h, width: w, height: h })
+    }
+    const bytes = await pdf.save()
+    postMessage({ id, blob: new Blob([bytes as unknown as BlobPart], { type: 'application/pdf' }) } satisfies SignResponse)
+  } catch {
+    postMessage({ id, blob: null } satisfies SignResponse)
+  }
+}

--- a/src/tools/pdf-split/PdfSplitTool.tsx
+++ b/src/tools/pdf-split/PdfSplitTool.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { zipStore } from '../../lib/zip'
 import { Button, Field, Input, Stack, Seg, SegButton } from '../../components/ui'
+import { PdfOps } from '../../lib/pdfOps'
 
 const STR = {
   en: {
@@ -43,17 +44,20 @@ export default function PdfSplitTool() {
   const [extractOut, setExtractOut] = useState<{ url: string; size: number; count: number } | null>(null)
   const [pages, setPages] = useState<{ name: string; url: string }[]>([])
   const [zipUrl, setZipUrl] = useState('')
+  const opsRef = useRef<PdfOps | null>(null)
+
+  useEffect(() => () => opsRef.current?.dispose(), [])
 
   function reset() { setExtractOut(null); setPages([]); setZipUrl('') }
 
+  // All pdf-lib work runs in a worker (#154) — splitting a big PDF never janks the UI.
   async function onFile(f: File | undefined) {
     if (!f) return
     setErr(''); reset()
-    try {
-      const { PDFDocument } = await import('pdf-lib')
-      const doc = await PDFDocument.load(await f.arrayBuffer())
-      setSrc({ name: f.name.replace(/\.pdf$/i, ''), file: f, pages: doc.getPageCount() })
-    } catch { setSrc(null); setErr(s.locked) }
+    opsRef.current ??= new PdfOps()
+    const n = await opsRef.current.pageCount(f)
+    if (n === null) { setSrc(null); setErr(s.locked); return }
+    setSrc({ name: f.name.replace(/\.pdf$/i, ''), file: f, pages: n })
   }
 
   async function extract() {
@@ -62,14 +66,8 @@ export default function PdfSplitTool() {
     if (idx === null || idx.length === 0) { setErr(s.rangeBad); return }
     setErr(''); setBusy(true)
     try {
-      const { PDFDocument } = await import('pdf-lib')
-      const doc = await PDFDocument.load(await src.file.arrayBuffer())
-      const out = await PDFDocument.create()
-      const copied = await out.copyPages(doc, idx.map((i) => i - 1))
-      copied.forEach((p) => out.addPage(p))
-      const bytes = await out.save()
-      const blob = new Blob([bytes as BlobPart], { type: 'application/pdf' })
-      setExtractOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size, count: idx.length } })
+      const blob = await opsRef.current!.extract(src.file, idx.map((i) => i - 1))
+      if (blob) setExtractOut((prev) => { if (prev) URL.revokeObjectURL(prev.url); return { url: URL.createObjectURL(blob), size: blob.size, count: idx.length } })
     } finally { setBusy(false) }
   }
 
@@ -77,19 +75,15 @@ export default function PdfSplitTool() {
     if (!src) return
     setBusy(true)
     try {
-      const { PDFDocument } = await import('pdf-lib')
-      const doc = await PDFDocument.load(await src.file.arrayBuffer())
+      const bufs = await opsRef.current!.burst(src.file)
+      if (!bufs) return
       const files: { name: string; bytes: Uint8Array }[] = []
       const links: { name: string; url: string }[] = []
-      for (let i = 0; i < src.pages; i++) {
-        const out = await PDFDocument.create()
-        const [p] = await out.copyPages(doc, [i])
-        out.addPage(p)
-        const bytes = await out.save()
+      bufs.forEach((buf, i) => {
         const name = `${src.name}-p${i + 1}.pdf`
-        files.push({ name, bytes })
-        links.push({ name, url: URL.createObjectURL(new Blob([bytes as BlobPart], { type: 'application/pdf' })) })
-      }
+        files.push({ name, bytes: new Uint8Array(buf) })
+        links.push({ name, url: URL.createObjectURL(new Blob([buf], { type: 'application/pdf' })) })
+      })
       pages.forEach((p) => URL.revokeObjectURL(p.url)); if (zipUrl) URL.revokeObjectURL(zipUrl)
       setPages(links)
       setZipUrl(URL.createObjectURL(zipStore(files)))

--- a/src/tools/steganography/SteganographyTool.tsx
+++ b/src/tools/steganography/SteganographyTool.tsx
@@ -1,108 +1,81 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { UploadIcon, DownloadIcon } from '../../components/icons'
 import { Button, Stack, Seg, SegButton, Textarea, Field } from '../../components/ui'
-
-const MAGIC = 0x42495342 // "BISB" marker so reveal can tell a real payload apart
+import type { StegoRequest, StegoResponse } from './stego.worker'
 
 const STR = {
   en: {
     hide: 'Hide', reveal: 'Reveal', drop: 'Drop an image (cover), or tap to choose', dropReveal: 'Drop an image with a hidden message',
-    message: 'Secret message', embed: 'Hide & download PNG', revealed: 'Revealed message', none: 'No hidden message found in this image.',
+    message: 'Secret message', embed: 'Hide & download PNG', working: 'Working…', revealed: 'Revealed message', none: 'No hidden message found in this image.',
     tooBig: 'Message is too long for this image. Use a larger image or shorter text.', change: 'Choose another image',
     note: 'This hides text in the pixels (LSB). It obscures a message but is not strong encryption — for real secrecy, encrypt first. Save as PNG; re-compressing to JPEG destroys the hidden data.',
     privacy: 'Everything runs on your device — nothing is uploaded.',
   },
   ar: {
     hide: 'إخفاء', reveal: 'كشف', drop: 'أفلت صورة (غطاء) أو اضغط للاختيار', dropReveal: 'أفلت صورة تحوي رسالة مخفية',
-    message: 'الرسالة السرية', embed: 'أخفِ ونزّل PNG', revealed: 'الرسالة المكشوفة', none: 'لا رسالة مخفية في هذه الصورة.',
+    message: 'الرسالة السرية', embed: 'أخفِ ونزّل PNG', working: 'جارٍ العمل…', revealed: 'الرسالة المكشوفة', none: 'لا رسالة مخفية في هذه الصورة.',
     tooBig: 'الرسالة أطول من سعة هذه الصورة. استخدم صورة أكبر أو نصًّا أقصر.', change: 'اختر صورة أخرى',
     note: 'يُخفي النص في البكسلات (LSB). يُخفي الرسالة لكنه ليس تشفيرًا قويًا — للسرية الحقيقية شفّر أولًا. احفظ كـPNG؛ فإعادة الضغط إلى JPEG تتلف البيانات المخفية.',
     privacy: 'كل شيء يجري على جهازك — لا يُرفع أي شيء.',
   },
 }
 
-function imageData(bmp: ImageBitmap): ImageData {
-  const c = document.createElement('canvas'); c.width = bmp.width; c.height = bmp.height
-  const ctx = c.getContext('2d', { willReadFrequently: true })!
-  ctx.drawImage(bmp, 0, 0)
-  return ctx.getImageData(0, 0, bmp.width, bmp.height)
-}
-const setBit = (v: number, bit: number) => (v & 0xfe) | bit
-
 export default function SteganographyTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const fileRef = useRef<HTMLInputElement>(null)
   const [mode, setMode] = useState<'hide' | 'reveal'>('hide')
-  const [bitmap, setBitmap] = useState<ImageBitmap | null>(null)
+  const [file, setFile] = useState<File | null>(null)
   const [message, setMessage] = useState('')
   const [revealed, setRevealed] = useState<string | null>(null)
-  const [error, setError] = useState('')
+  const [tooBig, setTooBig] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const workerRef = useRef<Worker | null>(null)
+  const reqRef = useRef(0)
 
-  async function onFile(f: File | undefined) {
-    if (!f || !f.type.startsWith('image/')) return
-    setError(''); setRevealed(null)
-    try { const bmp = await createImageBitmap(f); setBitmap(bmp); if (mode === 'reveal') doReveal(bmp) } catch { /* */ }
-  }
+  useEffect(() => () => { workerRef.current?.terminate() }, [])
 
-  function bitsOf(bytes: Uint8Array): number[] {
-    const bits: number[] = []
-    for (const b of bytes) for (let i = 7; i >= 0; i--) bits.push((b >> i) & 1)
-    return bits
-  }
-
-  function embed() {
-    if (!bitmap) return
-    const data = imageData(bitmap)
-    const payload = new TextEncoder().encode(message)
-    const header = new Uint8Array(8)
-    new DataView(header.buffer).setUint32(0, MAGIC); new DataView(header.buffer).setUint32(4, payload.length)
-    const bits = bitsOf(header).concat(bitsOf(payload))
-    // 3 channels (RGB) per pixel carry one bit each
-    const capacity = Math.floor((data.data.length / 4) * 3)
-    if (bits.length > capacity) { setError(s.tooBig); return }
-    let bi = 0
-    for (let p = 0; p < data.data.length && bi < bits.length; p += 4) {
-      for (let ch = 0; ch < 3 && bi < bits.length; ch++) data.data[p + ch] = setBit(data.data[p + ch], bits[bi++])
-    }
-    const c = document.createElement('canvas'); c.width = data.width; c.height = data.height
-    c.getContext('2d')!.putImageData(data, 0, 0)
-    c.toBlob((b) => { if (!b) return; const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = 'hidden.png'; a.click(); setTimeout(() => URL.revokeObjectURL(a.href), 1000) }, 'image/png')
-    setError('')
-  }
-
-  function doReveal(bmp: ImageBitmap) {
-    const data = imageData(bmp)
-    const readBits = (count: number, start: number) => {
-      const out: number[] = []
-      let idx = start
-      for (let p = 0; p < data.data.length && out.length < count; p += 4) {
-        for (let ch = 0; ch < 3 && out.length < count; ch++) { if (idx <= 0) out.push(data.data[p + ch] & 1); else idx-- }
+  // Pixel loops run in a worker (#154); responses are matched by id so a
+  // newly-dropped image cancels whatever the previous one was doing.
+  function run(req: { op: 'embed'; file: File; message: string } | { op: 'reveal'; file: File }) {
+    if (!workerRef.current) {
+      workerRef.current = new Worker(new URL('./stego.worker.ts', import.meta.url), { type: 'module' })
+      workerRef.current.onmessage = (e: MessageEvent<StegoResponse>) => {
+        if (e.data.id !== reqRef.current) return
+        setBusy(false)
+        if (e.data.op === 'embed') {
+          if (!e.data.blob) { setTooBig(true); return }
+          const a = document.createElement('a')
+          a.href = URL.createObjectURL(e.data.blob); a.download = 'hidden.png'; a.click()
+          setTimeout(() => URL.revokeObjectURL(a.href), 1000)
+        } else {
+          setRevealed(e.data.message ?? '')
+        }
       }
-      return out
     }
-    const bitsToBytes = (bits: number[]) => { const bytes = new Uint8Array(bits.length / 8); for (let i = 0; i < bytes.length; i++) { let v = 0; for (let j = 0; j < 8; j++) v = (v << 1) | bits[i * 8 + j]; bytes[i] = v } return bytes }
-    const headerBits = readBits(64, 0)
-    const header = bitsToBytes(headerBits)
-    const dv = new DataView(header.buffer)
-    if (dv.getUint32(0) !== MAGIC) { setRevealed(''); return }
-    const len = dv.getUint32(4)
-    if (len <= 0 || len > (data.data.length / 4) * 3) { setRevealed(''); return }
-    const msgBits = readBits(len * 8, 64)
-    setRevealed(new TextDecoder().decode(bitsToBytes(msgBits)))
+    setBusy(true); setTooBig(false)
+    workerRef.current.postMessage({ ...req, id: ++reqRef.current } as StegoRequest)
   }
+
+  function onFile(f: File | undefined) {
+    if (!f || !f.type.startsWith('image/')) return
+    setTooBig(false); setRevealed(null); setFile(f)
+    if (mode === 'reveal') run({ op: 'reveal', file: f })
+  }
+
+  function reset() { setFile(null); setRevealed(null); setTooBig(false); setBusy(false); reqRef.current++ }
 
   const dropLabel = mode === 'hide' ? s.drop : s.dropReveal
 
   return (
     <Stack data-testid="steganography">
       <Seg className="self-start">
-        <SegButton active={mode === 'hide'} onClick={() => { setMode('hide'); setBitmap(null); setRevealed(null); setError('') }} data-testid="stego-hide">{s.hide}</SegButton>
-        <SegButton active={mode === 'reveal'} onClick={() => { setMode('reveal'); setBitmap(null); setRevealed(null); setError('') }} data-testid="stego-reveal">{s.reveal}</SegButton>
+        <SegButton active={mode === 'hide'} onClick={() => { setMode('hide'); reset() }} data-testid="stego-hide">{s.hide}</SegButton>
+        <SegButton active={mode === 'reveal'} onClick={() => { setMode('reveal'); reset() }} data-testid="stego-reveal">{s.reveal}</SegButton>
       </Seg>
 
-      {!bitmap ? (
+      {!file ? (
         <button className="relative flex flex-col items-center gap-[0.4rem] py-8 px-4 border-2 border-dashed border-[color:var(--line)] rounded-[var(--r-md)] bg-[var(--surface)] text-center cursor-pointer hover:border-[color:color-mix(in_srgb,var(--green-500)_45%,transparent)]" data-testid="stego-drop" onClick={() => fileRef.current?.click()}
           onDragOver={(e) => e.preventDefault()} onDrop={(e) => { e.preventDefault(); onFile(e.dataTransfer.files[0]) }}>
           <UploadIcon /><span>{dropLabel}</span>
@@ -111,18 +84,18 @@ export default function SteganographyTool() {
       ) : mode === 'hide' ? (
         <>
           <Field label={s.message}><Textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={4} data-testid="stego-message" /></Field>
-          {error && <p className="text-[color:var(--danger)] text-[0.9rem]" data-testid="stego-error">{error}</p>}
+          {tooBig && <p className="text-[color:var(--danger)] text-[0.9rem]" data-testid="stego-error">{s.tooBig}</p>}
           <div className="flex gap-2">
-            <Button variant="primary" onClick={embed} disabled={!message} data-testid="stego-embed"><DownloadIcon /> {s.embed}</Button>
-            <Button onClick={() => setBitmap(null)}>{s.change}</Button>
+            <Button variant="primary" onClick={() => run({ op: 'embed', file, message })} disabled={!message || busy} data-testid="stego-embed"><DownloadIcon /> {busy ? s.working : s.embed}</Button>
+            <Button onClick={reset}>{s.change}</Button>
           </div>
         </>
       ) : (
         <>
-          {revealed
+          {busy ? <p className="text-ink-faint">{s.working}</p> : revealed
             ? <Field label={s.revealed}><Textarea value={revealed} readOnly rows={4} data-testid="stego-revealed" /></Field>
             : revealed === '' ? <p className="text-ink-soft text-[0.95rem]" data-testid="stego-none">{s.none}</p> : null}
-          <Button onClick={() => { setBitmap(null); setRevealed(null) }}>{s.change}</Button>
+          <Button onClick={reset}>{s.change}</Button>
         </>
       )}
 

--- a/src/tools/steganography/stego.worker.ts
+++ b/src/tools/steganography/stego.worker.ts
@@ -1,0 +1,72 @@
+// LSB embed/reveal loops touch every pixel, so they run here off the main
+// thread (#154). The File decodes here too (createImageBitmap + OffscreenCanvas
+// both exist in workers) — the image never blocks the UI.
+const MAGIC = 0x42495342 // "BISB" marker so reveal can tell a real payload apart
+
+export type StegoRequest =
+  | { id: number; op: 'embed'; file: File; message: string }
+  | { id: number; op: 'reveal'; file: File }
+export type StegoResponse =
+  | { id: number; op: 'embed'; blob: Blob | null; tooBig?: boolean }
+  | { id: number; op: 'reveal'; message: string | null }
+
+async function imageData(file: File): Promise<ImageData> {
+  const bmp = await createImageBitmap(file)
+  const c = new OffscreenCanvas(bmp.width, bmp.height)
+  const ctx = c.getContext('2d', { willReadFrequently: true })!
+  ctx.drawImage(bmp, 0, 0)
+  bmp.close()
+  return ctx.getImageData(0, 0, c.width, c.height)
+}
+
+const setBit = (v: number, bit: number) => (v & 0xfe) | bit
+
+function bitsOf(bytes: Uint8Array): number[] {
+  const bits: number[] = []
+  for (const b of bytes) for (let i = 7; i >= 0; i--) bits.push((b >> i) & 1)
+  return bits
+}
+
+async function embed(file: File, message: string): Promise<StegoResponse & { op: 'embed' }> {
+  const data = await imageData(file)
+  const payload = new TextEncoder().encode(message)
+  const header = new Uint8Array(8)
+  new DataView(header.buffer).setUint32(0, MAGIC); new DataView(header.buffer).setUint32(4, payload.length)
+  const bits = bitsOf(header).concat(bitsOf(payload))
+  // 3 channels (RGB) per pixel carry one bit each
+  const capacity = Math.floor((data.data.length / 4) * 3)
+  if (bits.length > capacity) return { id: 0, op: 'embed', blob: null, tooBig: true }
+  let bi = 0
+  for (let p = 0; p < data.data.length && bi < bits.length; p += 4) {
+    for (let ch = 0; ch < 3 && bi < bits.length; ch++) data.data[p + ch] = setBit(data.data[p + ch], bits[bi++])
+  }
+  const c = new OffscreenCanvas(data.width, data.height)
+  c.getContext('2d')!.putImageData(data, 0, 0)
+  const blob = await c.convertToBlob({ type: 'image/png' })
+  return { id: 0, op: 'embed', blob }
+}
+
+async function reveal(file: File): Promise<StegoResponse & { op: 'reveal' }> {
+  const data = await imageData(file)
+  const readBits = (count: number, start: number) => {
+    const out: number[] = []
+    let idx = start
+    for (let p = 0; p < data.data.length && out.length < count; p += 4) {
+      for (let ch = 0; ch < 3 && out.length < count; ch++) { if (idx <= 0) out.push(data.data[p + ch] & 1); else idx-- }
+    }
+    return out
+  }
+  const bitsToBytes = (bits: number[]) => { const bytes = new Uint8Array(bits.length / 8); for (let i = 0; i < bytes.length; i++) { let v = 0; for (let j = 0; j < 8; j++) v = (v << 1) | bits[i * 8 + j]; bytes[i] = v } return bytes }
+  const header = bitsToBytes(readBits(64, 0))
+  const dv = new DataView(header.buffer)
+  if (dv.getUint32(0) !== MAGIC) return { id: 0, op: 'reveal', message: null }
+  const len = dv.getUint32(4)
+  if (len <= 0 || len > (data.data.length / 4) * 3) return { id: 0, op: 'reveal', message: null }
+  return { id: 0, op: 'reveal', message: new TextDecoder().decode(bitsToBytes(readBits(len * 8, 64))) }
+}
+
+self.onmessage = async (e: MessageEvent<StegoRequest>) => {
+  const req = e.data
+  const res = req.op === 'embed' ? await embed(req.file, req.message) : await reveal(req.file)
+  postMessage({ ...res, id: req.id } satisfies StegoResponse)
+}

--- a/src/tools/zip-inspector/ZipInspectorTool.tsx
+++ b/src/tools/zip-inspector/ZipInspectorTool.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '../../i18n'
 import { Stack } from '../../components/ui'
+import type { Entry, ZipRequest, ZipResponse } from './zip.worker'
 
 const STR = {
   en: {
@@ -21,8 +22,6 @@ const STR = {
   },
 }
 
-interface Entry { name: string; size: number; comp: number; method: number; date: Date | null; dir: boolean }
-
 const fmtBytes = (n: number) => {
   if (n < 1024) return `${n} B`
   const u = ['KB', 'MB', 'GB']; let i = -1; let v = n
@@ -30,70 +29,28 @@ const fmtBytes = (n: number) => {
   return `${v.toFixed(v < 10 ? 1 : 0)} ${u[i]}`
 }
 
-// Detect common archive/compression formats by magic bytes.
-function detectFormat(b: Uint8Array): string {
-  const h = (n: number) => b[n]
-  if (h(0) === 0x50 && h(1) === 0x4b && (h(2) === 0x03 || h(2) === 0x05 || h(2) === 0x07)) return 'ZIP'
-  if (h(0) === 0x1f && h(1) === 0x8b) return 'GZIP'
-  if (h(0) === 0x42 && h(1) === 0x5a && h(2) === 0x68) return 'BZIP2'
-  if (h(0) === 0xfd && h(1) === 0x37 && h(2) === 0x7a && h(3) === 0x58 && h(4) === 0x5a) return 'XZ'
-  if (h(0) === 0x37 && h(1) === 0x7a && h(2) === 0xbc && h(3) === 0xaf) return '7-Zip'
-  if (h(0) === 0x52 && h(1) === 0x61 && h(2) === 0x72 && h(3) === 0x21) return 'RAR'
-  if (h(0) === 0x04 && h(1) === 0x22 && h(2) === 0x4d && h(3) === 0x18) return 'LZ4'
-  if (h(0) === 0x28 && h(1) === 0xb5 && h(2) === 0x2f && h(3) === 0xfd) return 'Zstandard'
-  // tar: "ustar" at offset 257
-  if (b.length > 262 && b[257] === 0x75 && b[258] === 0x73 && b[259] === 0x74 && b[260] === 0x61 && b[261] === 0x72) return 'TAR'
-  return ''
-}
-
-// Parse a ZIP central directory. Returns null if not a valid ZIP.
-function parseZip(buf: ArrayBuffer): Entry[] | null {
-  const dv = new DataView(buf)
-  const n = buf.byteLength
-  // Find End Of Central Directory (signature 0x06054b50), scanning back from the end.
-  let eocd = -1
-  for (let i = n - 22; i >= Math.max(0, n - 22 - 65536); i--) {
-    if (dv.getUint32(i, true) === 0x06054b50) { eocd = i; break }
-  }
-  if (eocd < 0) return null
-  const count = dv.getUint16(eocd + 10, true)
-  let off = dv.getUint32(eocd + 16, true)
-  const dec = new TextDecoder()
-  const out: Entry[] = []
-  for (let i = 0; i < count && off + 46 <= n; i++) {
-    if (dv.getUint32(off, true) !== 0x02014b50) break
-    const method = dv.getUint16(off + 10, true)
-    const dosTime = dv.getUint16(off + 12, true)
-    const dosDate = dv.getUint16(off + 14, true)
-    const comp = dv.getUint32(off + 20, true)
-    const size = dv.getUint32(off + 24, true)
-    const nameLen = dv.getUint16(off + 28, true)
-    const extraLen = dv.getUint16(off + 30, true)
-    const commentLen = dv.getUint16(off + 32, true)
-    const name = dec.decode(new Uint8Array(buf, off + 46, nameLen))
-    let date: Date | null = null
-    if (dosDate) {
-      date = new Date(1980 + (dosDate >> 9), ((dosDate >> 5) & 0xf) - 1, dosDate & 0x1f,
-        dosTime >> 11, (dosTime >> 5) & 0x3f, (dosTime & 0x1f) * 2)
-    }
-    out.push({ name, size, comp, method, date, dir: name.endsWith('/') })
-    off += 46 + nameLen + extraLen + commentLen
-  }
-  return out
-}
-
 export default function ZipInspectorTool() {
   const { locale } = useLocale()
   const s = STR[locale]
   const [file, setFile] = useState<{ name: string; format: string; entries: Entry[] | null } | null>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const reqRef = useRef(0)
   const dateFmt = new Intl.DateTimeFormat(locale === 'ar' ? 'ar-SA' : 'en-GB', { dateStyle: 'medium', timeStyle: 'short' })
 
-  async function handle(f: File) {
-    const buf = await f.arrayBuffer()
-    const head = new Uint8Array(buf.slice(0, 512))
-    const format = detectFormat(head) || s.unknown
-    const entries = format === 'ZIP' ? parseZip(buf) : null
-    setFile({ name: f.name, format, entries })
+  useEffect(() => () => { workerRef.current?.terminate() }, [])
+
+  // Reading + parsing happen in a worker so huge archives never jank the UI (#154).
+  function handle(f: File) {
+    workerRef.current ??= new Worker(new URL('./zip.worker.ts', import.meta.url), { type: 'module' })
+    const worker = workerRef.current
+    const id = ++reqRef.current
+    const onMessage = (e: MessageEvent<ZipResponse>) => {
+      if (e.data.id !== reqRef.current) return // a newer file was dropped meanwhile
+      worker.removeEventListener('message', onMessage)
+      setFile({ name: f.name, format: e.data.format || s.unknown, entries: e.data.entries })
+    }
+    worker.addEventListener('message', onMessage)
+    worker.postMessage({ id, file: f } satisfies ZipRequest)
   }
 
   const totals = file?.entries

--- a/src/tools/zip-inspector/zip.worker.ts
+++ b/src/tools/zip-inspector/zip.worker.ts
@@ -1,0 +1,65 @@
+// Archive sniffing + ZIP central-directory parsing run here so a multi-GB
+// archive is read and walked off the main thread (#154).
+export interface Entry { name: string; size: number; comp: number; method: number; date: Date | null; dir: boolean }
+export interface ZipRequest { id: number; file: File }
+export interface ZipResponse { id: number; format: string; entries: Entry[] | null }
+
+// Detect common archive/compression formats by magic bytes.
+function detectFormat(b: Uint8Array): string {
+  const h = (n: number) => b[n]
+  if (h(0) === 0x50 && h(1) === 0x4b && (h(2) === 0x03 || h(2) === 0x05 || h(2) === 0x07)) return 'ZIP'
+  if (h(0) === 0x1f && h(1) === 0x8b) return 'GZIP'
+  if (h(0) === 0x42 && h(1) === 0x5a && h(2) === 0x68) return 'BZIP2'
+  if (h(0) === 0xfd && h(1) === 0x37 && h(2) === 0x7a && h(3) === 0x58 && h(4) === 0x5a) return 'XZ'
+  if (h(0) === 0x37 && h(1) === 0x7a && h(2) === 0xbc && h(3) === 0xaf) return '7-Zip'
+  if (h(0) === 0x52 && h(1) === 0x61 && h(2) === 0x72 && h(3) === 0x21) return 'RAR'
+  if (h(0) === 0x04 && h(1) === 0x22 && h(2) === 0x4d && h(3) === 0x18) return 'LZ4'
+  if (h(0) === 0x28 && h(1) === 0xb5 && h(2) === 0x2f && h(3) === 0xfd) return 'Zstandard'
+  // tar: "ustar" at offset 257
+  if (b.length > 262 && b[257] === 0x75 && b[258] === 0x73 && b[259] === 0x74 && b[260] === 0x61 && b[261] === 0x72) return 'TAR'
+  return ''
+}
+
+// Parse a ZIP central directory. Returns null if not a valid ZIP.
+function parseZip(buf: ArrayBuffer): Entry[] | null {
+  const dv = new DataView(buf)
+  const n = buf.byteLength
+  // Find End Of Central Directory (signature 0x06054b50), scanning back from the end.
+  let eocd = -1
+  for (let i = n - 22; i >= Math.max(0, n - 22 - 65536); i--) {
+    if (dv.getUint32(i, true) === 0x06054b50) { eocd = i; break }
+  }
+  if (eocd < 0) return null
+  const count = dv.getUint16(eocd + 10, true)
+  let off = dv.getUint32(eocd + 16, true)
+  const dec = new TextDecoder()
+  const out: Entry[] = []
+  for (let i = 0; i < count && off + 46 <= n; i++) {
+    if (dv.getUint32(off, true) !== 0x02014b50) break
+    const method = dv.getUint16(off + 10, true)
+    const dosTime = dv.getUint16(off + 12, true)
+    const dosDate = dv.getUint16(off + 14, true)
+    const comp = dv.getUint32(off + 20, true)
+    const size = dv.getUint32(off + 24, true)
+    const nameLen = dv.getUint16(off + 28, true)
+    const extraLen = dv.getUint16(off + 30, true)
+    const commentLen = dv.getUint16(off + 32, true)
+    const name = dec.decode(new Uint8Array(buf, off + 46, nameLen))
+    let date: Date | null = null
+    if (dosDate) {
+      date = new Date(1980 + (dosDate >> 9), ((dosDate >> 5) & 0xf) - 1, dosDate & 0x1f,
+        dosTime >> 11, (dosTime >> 5) & 0x3f, (dosTime & 0x1f) * 2)
+    }
+    out.push({ name, size, comp, method, date, dir: name.endsWith('/') })
+    off += 46 + nameLen + extraLen + commentLen
+  }
+  return out
+}
+
+self.onmessage = async (e: MessageEvent<ZipRequest>) => {
+  const { id, file } = e.data
+  const buf = await file.arrayBuffer()
+  const format = detectFormat(new Uint8Array(buf.slice(0, 512)))
+  const entries = format === 'ZIP' ? parseZip(buf) : null
+  postMessage({ id, format, entries } satisfies ZipResponse)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -172,4 +172,7 @@ export default defineConfig({
   plugins: [tailwindcss(), react(), prerenderPlugin()],
   base: '/',
   build: { target: 'es2020', sourcemap: false },
+  // Tool workers lazy-import pdf-lib inside the worker (code-splitting), which
+  // the default iife worker format can't do.
+  worker: { format: 'es' },
 })


### PR DESCRIPTION
Implements the sweep approved in #154, five commits, each verified (typecheck + build + full e2e green; suite grew 119 → 122).

**Moved to workers:**
- **hash-generator** — digest in `hash.worker.ts`; the `File` handle is read inside the worker.
- **steganography** — LSB embed/reveal per-pixel loops (`stego.worker.ts`, OffscreenCanvas).
- **archive-inspector** — archive read + ZIP central-directory parse (`zip.worker.ts`).
- **image-compressor / image-format-converter / image-cropper** — shared `lib/imageEncode.worker.ts` (holds the decoded bitmap; crop/scale/encode per slider/drag change). The cropper was the worst offender: full-res crop re-encode on every pointer move.
- **pdf-merge / pdf-split** — shared `lib/pdfOps.worker.ts` (pageCount/merge/extract/burst; burst transfers page buffers).
- **pdf-sign** — signature stamping in `sign.worker.ts`.
- **pdf-edit** — content-stream parsing on load and the rebuild on save in `edit.worker.ts`.

**Skipped as not applicable:** image-to-ascii (≤300-char downscaled grid), image-redact + meme-generator (interactive on-DOM canvas, GPU drawImage), favicon-generator (8 small one-off resizes), remove-background (imgly already runs its ONNX in a worker).

**Infra:** `vite.config.ts` sets `worker: { format: 'es' }` — workers that lazy-import pdf-lib need code-splitting, which iife workers reject at build time. New `e2e/workers.spec.ts` drives real files through every worker-backed tool (incl. a stego hide→reveal round-trip and merge/extract/burst). Convention documented in CLAUDE.md.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)