### PR TITLE
Add Hajj & Umrah guide app (#236)

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -653,6 +653,25 @@ test.describe('tools', () => {
     await page.getByTestId('adhkar-evening').click()
     await expect(page.getByTestId('dhikr-amsayna-evening')).toBeVisible()
   })
+
+  test('hajj-umrah: rite + level switch, tap to mark a step done', async ({ page }) => {
+    await page.goto('/en/tools/hajj-umrah')
+    // Defaults to ʿUmrah, full guide (recommended visible).
+    const tawaf = page.getByTestId('step-u-tawaf')
+    await expect(tawaf).toBeVisible()
+    await expect(page.getByTestId('step-u-ghusl')).toBeVisible() // a recommended step
+    // Tap to complete — the card dims.
+    await tawaf.click()
+    await expect(tawaf).toHaveClass(/opacity-60/)
+    // Obligatory filter hides the sunnah steps.
+    await page.getByTestId('level-obligatory').click()
+    await expect(page.getByTestId('step-u-ghusl')).toHaveCount(0)
+    await expect(page.getByTestId('step-u-tawaf')).toBeVisible()
+    // Switching to Ḥajj shows its rites.
+    await page.getByTestId('rite-hajj').click()
+    await expect(page.getByTestId('step-h-arafah')).toBeVisible()
+    await expect(page.getByTestId('step-u-tawaf')).toHaveCount(0)
+  })
 })
 
 test.describe('shell', () => {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -996,6 +996,20 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://built-in-saudi.com/en/apps/adhkar"/>
   </url>
   <url>
+    <loc>https://built-in-saudi.com/en/apps/hajj-umrah/</loc>
+    <lastmod>2026-07-30</lastmod><changefreq>monthly</changefreq><priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://built-in-saudi.com/en/apps/hajj-umrah"/>
+    <xhtml:link rel="alternate" hreflang="ar" href="https://built-in-saudi.com/ar/apps/hajj-umrah"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://built-in-saudi.com/en/apps/hajj-umrah"/>
+  </url>
+  <url>
+    <loc>https://built-in-saudi.com/ar/apps/hajj-umrah/</loc>
+    <lastmod>2026-07-30</lastmod><changefreq>monthly</changefreq><priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://built-in-saudi.com/en/apps/hajj-umrah"/>
+    <xhtml:link rel="alternate" hreflang="ar" href="https://built-in-saudi.com/ar/apps/hajj-umrah"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://built-in-saudi.com/en/apps/hajj-umrah"/>
+  </url>
+  <url>
     <loc>https://built-in-saudi.com/en/apps/hisn-al-muslim/</loc>
     <lastmod>2026-07-02</lastmod><changefreq>monthly</changefreq><priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://built-in-saudi.com/en/apps/hisn-al-muslim"/>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -531,6 +531,15 @@ export function MosqueIcon({ className }: P) {
   )
 }
 
+export function KaabaIcon({ className }: P) {
+  return (
+    <svg {...base} className={className} aria-hidden="true">
+      <path d="M6 8h12v12H6z" /><path d="M6 11h12" />
+      <path d="M13.5 20v-4h2v4" /><path d="M4 20h16" />
+    </svg>
+  )
+}
+
 export function FeatherIcon({ className }: P) {
   return (
     <svg {...base} className={className} aria-hidden="true">

--- a/src/i18n/seo.ts
+++ b/src/i18n/seo.ts
@@ -461,6 +461,11 @@ export const liveToolSeo: ToolSeo[] = [
     ar: { name: 'أذكار الصباح والمساء', description: 'أذكار الصباح والمساء الأساسية من القرآن والسنة الصحيحة — بالعربية مع النطق والمعنى بالإنجليزية وعدد التكرار والمصدر وعدّاد باللمس.' },
   },
   {
+    id: 'hajj-umrah',
+    en: { name: 'Hajj & Umrah Guide', description: 'A step-by-step guide to ʿUmrah and Ḥajj — every act with its supplication and its fiqh ruling. Switch between ʿUmrah (default) and Ḥajj, show just the pillars and duties or the full guide with the sunan, and track your progress. Fully offline.' },
+    ar: { name: 'دليل الحج والعمرة', description: 'دليل خطوةً بخطوة لأداء العمرة والحج — كل عمل مع دعائه وحكمه الفقهي. بدّل بين العمرة (الافتراضية) والحج، واعرض الأركان والواجبات فقط أو الدليل كاملًا مع السنن، وتتبّع تقدّمك. يعمل دون اتصال.' },
+  },
+  {
     id: 'istikhara',
     en: { name: 'Istikhara Du‘a', description: 'The du‘a of Ṣalāt al-Istikhāra (the prayer for guidance) — the prophetic Arabic with transliteration, an English meaning, how to pray the two rakʿahs, and the source (Jābir ibn ʿAbdillāh · Ṣaḥīḥ al-Bukhārī).' },
     ar: { name: 'دعاء الاستخارة', description: 'دعاء صلاة الاستخارة — النص النبوي بالعربية مع النطق والمعنى بالإنجليزية، وكيفية أداء الركعتين، والمصدر (جابر بن عبد الله · صحيح البخاري).' },

--- a/src/tools/hajj-umrah/HajjUmrahTool.tsx
+++ b/src/tools/hajj-umrah/HajjUmrahTool.tsx
@@ -15,7 +15,8 @@ const STR = {
     },
     dua: 'Supplication', copy: 'Copy', copied: 'Copied',
     reset: 'Reset', progress: 'Progress', count: (d: number, t: number) => `${d} / ${t}`,
-    note: 'A study aid, not a fatwā: the Arabic is the Qur’ān/Sunnah text, while the transliteration, meanings and summaries were written for this app. Follow a trustworthy scholar or guide for your Ḥajj.',
+    note: 'A study aid, not a fatwā. The rulings (rukn / wājib / sunnah) follow the manāsik of Shaykh Ibn Bāz and the fatwās of the Permanent Committee; the procedure follows the Saudi Ministry of Ḥajj & ʿUmrah. The Arabic supplications are the Qur’ān/Sunnah text; the transliteration and meanings were written for this app. Follow a trustworthy scholar or an official guide for your Ḥajj.',
+    sources: 'Sources',
   },
   ar: {
     umrah: 'العمرة', hajj: 'الحج',
@@ -26,9 +27,20 @@ const STR = {
     },
     dua: 'الدعاء', copy: 'نسخ', copied: 'تم النسخ',
     reset: 'تصفير', progress: 'التقدّم', count: (d: number, t: number) => `${d} / ${t}`,
-    note: 'هذا دليل للتعلّم لا فتوى: النص العربي من القرآن والسنة، وكُتبت الترجمة والنطق والملخّصات لهذا التطبيق. اتّبع في حجّك عالِمًا موثوقًا أو مرشدًا.',
+    note: 'هذا دليل للتعلّم لا فتوى. الأحكام (ركن / واجب / سنة) على منسك الشيخ ابن باز وفتاوى اللجنة الدائمة، والصفة العملية على دليل وزارة الحج والعمرة. والنص العربي للأدعية من القرآن والسنة، وكُتبت الترجمة والنطق لهذا التطبيق. اتّبع في حجّك عالِمًا موثوقًا أو مرشدًا رسميًّا.',
+    sources: 'المصادر',
   },
 }
+
+// KSA-aligned references: the fiqh classifications follow the manāsik of the
+// late Grand Mufti Shaykh Ibn Bāz (the rulings the Saudi religious establishment
+// distributes); the procedure follows the Ministry of Ḥajj & ʿUmrah.
+const SOURCES: { href: string; en: string; ar: string }[] = [
+  { href: 'https://binbaz.org.sa/fatwas/14833/', en: 'Ibn Bāz — Pillars & obligations of Ḥajj', ar: 'ابن باز — أركان الحج وواجباته' },
+  { href: 'https://binbaz.org.sa/fatwas/11982/', en: 'Ibn Bāz — The description of ʿUmrah', ar: 'ابن باز — صفة العمرة' },
+  { href: 'https://binbaz.org.sa/fatwas/15743/', en: 'Ibn Bāz — Saʿy is a pillar of Ḥajj & ʿUmrah', ar: 'ابن باز — السعي ركن من أركان الحج والعمرة' },
+  { href: 'https://haj.gov.sa/en/Guides', en: 'Ministry of Ḥajj & ʿUmrah — official pilgrim guides', ar: 'وزارة الحج والعمرة — أدلة المناسك الرسمية' },
+]
 
 const storeKey = (rite: Rite) => `bis-hajj-${rite}`
 function loadDone(rite: Rite): Record<string, boolean> {
@@ -125,6 +137,20 @@ export default function HajjUmrahTool() {
       </ol>
 
       <p className="text-[0.78rem] text-ink-faint">{s.note}</p>
+
+      <div className="flex flex-col gap-1.5">
+        <h2 className="text-[0.7rem] font-semibold uppercase tracking-[0.06em] text-ink-faint rtl:tracking-normal m-0">{s.sources}</h2>
+        <ul className="list-none ps-0 m-0 flex flex-col gap-1">
+          {SOURCES.map((src) => (
+            <li key={src.href}>
+              <a href={src.href} target="_blank" rel="noopener noreferrer"
+                className="text-[0.8rem] text-green-600 underline decoration-[color:var(--line)] underline-offset-2 hover:decoration-current">
+                {src[locale]}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       {/* Persistent, edge-docked completion bar — how many steps you've marked
           done in the current view. Portaled to <body> so it stays viewport-fixed

--- a/src/tools/hajj-umrah/HajjUmrahTool.tsx
+++ b/src/tools/hajj-umrah/HajjUmrahTool.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useLocale } from '../../i18n'
+import { Seg, SegButton } from '../../components/ui'
+import { CopyIcon, CheckIcon, RefreshIcon } from '../../components/icons'
+import { STEPS, type Rite, type Level, type Step } from './data'
+
+const STR = {
+  en: {
+    umrah: 'ʿUmrah', hajj: 'Ḥajj',
+    obligatory: 'Obligatory', recommended: 'Recommended',
+    lede: {
+      umrah: 'The rite of ʿUmrah, step by step — each act with its supplication and its fiqh ruling. Tap a step to mark it done; your progress is kept on this device. Switch to “Obligatory” to see only the pillars and duties, or “Recommended” for the full guide with the sunan.',
+      hajj: 'The rite of Ḥajj, day by day (following the tamattuʿ many pilgrims perform — do ʿUmrah first). Tap a step to mark it done. Switch to “Obligatory” for just the pillars and duties, or “Recommended” for the full guide with the sunan.',
+    },
+    dua: 'Supplication', copy: 'Copy', copied: 'Copied',
+    reset: 'Reset', progress: 'Progress', count: (d: number, t: number) => `${d} / ${t}`,
+    note: 'A study aid, not a fatwā: the Arabic is the Qur’ān/Sunnah text, while the transliteration, meanings and summaries were written for this app. Follow a trustworthy scholar or guide for your Ḥajj.',
+  },
+  ar: {
+    umrah: 'العمرة', hajj: 'الحج',
+    obligatory: 'الأركان والواجبات', recommended: 'مع المستحبات',
+    lede: {
+      umrah: 'مناسك العمرة خطوةً بخطوة — كل عمل مع دعائه وحكمه الفقهي. اضغط الخطوة لتعليمها كمنجزة؛ ويُحفظ تقدّمك على جهازك. اختر «الأركان والواجبات» لعرض الفرائض فقط، أو «مع المستحبات» للدليل كاملًا مع السنن.',
+      hajj: 'مناسك الحج يومًا بيوم (على صفة التمتّع التي يؤدّيها كثير من الحجاج — تُقدَّم العمرة أولًا). اضغط الخطوة لتعليمها كمنجزة. اختر «الأركان والواجبات» للفرائض فقط، أو «مع المستحبات» للدليل كاملًا مع السنن.',
+    },
+    dua: 'الدعاء', copy: 'نسخ', copied: 'تم النسخ',
+    reset: 'تصفير', progress: 'التقدّم', count: (d: number, t: number) => `${d} / ${t}`,
+    note: 'هذا دليل للتعلّم لا فتوى: النص العربي من القرآن والسنة، وكُتبت الترجمة والنطق والملخّصات لهذا التطبيق. اتّبع في حجّك عالِمًا موثوقًا أو مرشدًا.',
+  },
+}
+
+const storeKey = (rite: Rite) => `bis-hajj-${rite}`
+function loadDone(rite: Rite): Record<string, boolean> {
+  try { return JSON.parse(localStorage.getItem(storeKey(rite)) || '{}') } catch { return {} }
+}
+
+export default function HajjUmrahTool() {
+  const { locale } = useLocale()
+  const s = STR[locale]
+  const [rite, setRite] = useState<Rite>('umrah')
+  const [level, setLevel] = useState<Level>('recommended')
+  const [done, setDone] = useState<Record<string, boolean>>(() => loadDone('umrah'))
+
+  // Obligatory = arkān + wājibāt only; Recommended shows everything (the sunan
+  // don't stand alone — they sit between the obligations).
+  const list = useMemo(
+    () => STEPS.filter((st) => st.rite === rite && (level === 'recommended' || st.level === 'obligatory')),
+    [rite, level],
+  )
+  const doneCount = list.reduce((n, st) => n + (done[st.id] ? 1 : 0), 0)
+  const pct = list.length ? Math.round((doneCount / list.length) * 100) : 0
+  const anyDone = doneCount > 0
+
+  // Per-phase completion (shown next to each day/phase heading).
+  const phaseStats = useMemo(() => {
+    const m = new Map<string, { done: number; total: number }>()
+    for (const st of list) {
+      const key = st.phase ? st.phase[locale] : ''
+      if (!key) continue
+      const cur = m.get(key) || { done: 0, total: 0 }
+      cur.total++
+      if (done[st.id]) cur.done++
+      m.set(key, cur)
+    }
+    return m
+  }, [list, done, locale])
+
+  function switchRite(r: Rite) { setRite(r); setDone(loadDone(r)) }
+
+  function toggle(id: string) {
+    setDone((d) => {
+      const nd = { ...d, [id]: !d[id] }
+      try { localStorage.setItem(storeKey(rite), JSON.stringify(nd)) } catch { /* ignore */ }
+      return nd
+    })
+  }
+
+  function reset() {
+    setDone({})
+    try { localStorage.removeItem(storeKey(rite)) } catch { /* ignore */ }
+  }
+
+  let lastPhase = ''
+
+  return (
+    <div className="flex flex-col gap-5 max-w-[46rem] mx-auto pb-16" data-testid="hajj-umrah">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <Seg role="group" aria-label="rite">
+          {(['umrah', 'hajj'] as Rite[]).map((r) => (
+            <SegButton key={r} active={rite === r} aria-pressed={rite === r}
+              data-testid={`rite-${r}`} onClick={() => switchRite(r)}>{s[r]}</SegButton>
+          ))}
+        </Seg>
+        <Seg role="group" aria-label="level">
+          {(['obligatory', 'recommended'] as Level[]).map((l) => (
+            <SegButton key={l} active={level === l} aria-pressed={level === l}
+              data-testid={`level-${l}`} onClick={() => setLevel(l)}>{s[l]}</SegButton>
+          ))}
+        </Seg>
+      </div>
+
+      <p className="text-[0.9rem] text-ink-soft leading-relaxed">{s.lede[rite]}</p>
+
+      <ol className="list-none ps-0 m-0 flex flex-col gap-3">
+        {list.map((st) => {
+          const phase = st.phase ? st.phase[locale] : ''
+          const showPhase = phase && phase !== lastPhase
+          const stat = showPhase ? phaseStats.get(phase) : undefined
+          if (phase) lastPhase = phase
+          return (
+            <li key={st.id} className="flex flex-col gap-3">
+              {showPhase && (
+                <div className="flex items-baseline justify-between gap-3 mt-2 pb-1.5 border-b border-[color:var(--line-soft)]">
+                  <h2 className="font-display text-[0.95rem] text-ink-soft m-0">{phase}</h2>
+                  {stat && (
+                    <span className="tabular-nums text-[0.72rem] font-semibold text-ink-faint flex-none">{s.count(stat.done, stat.total)}</span>
+                  )}
+                </div>
+              )}
+              <StepCard step={st} done={!!done[st.id]} onToggle={() => toggle(st.id)} locale={locale} s={s} />
+            </li>
+          )
+        })}
+      </ol>
+
+      <p className="text-[0.78rem] text-ink-faint">{s.note}</p>
+
+      {/* Persistent, edge-docked completion bar — how many steps you've marked
+          done in the current view. Portaled to <body> so it stays viewport-fixed
+          (the tool page's fadeUp transform would otherwise capture `fixed`). */}
+      {createPortal(
+        <div className="fixed inset-x-0 bottom-0 z-40 bg-[var(--surface)] border-t border-[color:var(--line)] shadow-[0_-2px_10px_color-mix(in_srgb,var(--ink)_8%,transparent)]"
+          dir={locale === 'ar' ? 'rtl' : 'ltr'}
+          role="progressbar" aria-valuemin={0} aria-valuemax={list.length} aria-valuenow={doneCount}
+          aria-label={s.progress} data-testid="hajj-overall">
+          <div className="max-w-[46rem] mx-auto px-4 py-2.5 flex items-center gap-3">
+            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.06em] text-ink-faint rtl:tracking-normal flex-none">{s.progress}</span>
+            <div className="flex-1 h-2 rounded-full bg-sand-200 overflow-hidden">
+              <div className="h-full bg-green-600 rounded-full transition-[width] duration-200" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="tabular-nums text-[0.82rem] font-semibold text-ink-soft flex-none">{s.count(doneCount, list.length)}</span>
+            <button type="button" onClick={reset} disabled={!anyDone} data-testid="hajj-reset"
+              aria-label={s.reset} title={s.reset}
+              className="flex-none flex items-center justify-center w-8 h-8 rounded-sm border border-[color:var(--line)] bg-[var(--surface)] text-ink-soft disabled:opacity-40 disabled:cursor-default enabled:hover:text-ink">
+              <RefreshIcon />
+            </button>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  )
+}
+
+function StepCard({ step, done, onToggle, locale, s }: {
+  step: Step; done: boolean; onToggle: () => void; locale: 'en' | 'ar'; s: typeof STR['en']
+}) {
+  const obligatory = step.level === 'obligatory'
+  const [copied, setCopied] = useState(false)
+
+  async function copyDua(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!step.dua) return
+    try { await navigator.clipboard.writeText(step.dua.ar); setCopied(true); setTimeout(() => setCopied(false), 1600) } catch { /* ignore */ }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid={`step-${step.id}`}
+      aria-pressed={done}
+      aria-label={step.title[locale]}
+      onClick={onToggle}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle() } }}
+      className={`rounded-md bg-[var(--surface)] p-4 flex flex-col gap-3 cursor-pointer select-none transition-[border-color,opacity] duration-150 ${done ? 'border border-[color:var(--line-soft)] opacity-60' : 'border-2 border-green-600'}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          {/* Tick box mirrors the done state at a glance. */}
+          <span aria-hidden="true" className={`w-5 h-5 rounded-sm border flex-none flex items-center justify-center ${done ? 'bg-green-600 border-green-600 text-sand-100' : 'border-[color:var(--line)]'}`}>
+            {done && (
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+            )}
+          </span>
+          <h3 className="font-display text-[1.05rem] text-ink m-0 truncate">{step.title[locale]}</h3>
+        </div>
+        <span className={`font-mono text-[0.62rem] font-semibold tracking-[0.06em] uppercase px-[0.5rem] py-[0.2rem] rounded-full flex-none rtl:tracking-normal ${obligatory ? 'bg-[color-mix(in_srgb,var(--color-green-400)_20%,transparent)] text-green-600' : 'bg-[color-mix(in_srgb,var(--color-gold-400)_22%,transparent)] text-gold-500'}`}>
+          {step.tag[locale]}
+        </span>
+      </div>
+
+      <p className="text-[0.92rem] text-ink-soft leading-relaxed m-0">{step.body[locale]}</p>
+
+      {step.dua && (
+        <div className="rounded-sm bg-[color-mix(in_srgb,var(--color-green-400)_8%,transparent)] border border-[color:var(--line-soft)] p-3 flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[0.68rem] font-semibold uppercase tracking-[0.06em] text-ink-faint rtl:tracking-normal">{s.dua}</span>
+            <button type="button" onClick={copyDua} data-testid={`dua-copy-${step.id}`}
+              aria-label={s.copy} className="flex items-center gap-1 text-[0.72rem] font-semibold text-ink-faint hover:text-ink">
+              {copied ? <CheckIcon /> : <CopyIcon />} {copied ? s.copied : s.copy}
+            </button>
+          </div>
+          <p dir="rtl" lang="ar" className="font-ar text-[1.3rem] leading-[2] text-ink m-0">{step.dua.ar}</p>
+          {locale !== 'ar' && <p className="text-[0.85rem] text-ink-soft italic leading-relaxed m-0">{step.dua.translit}</p>}
+          {locale !== 'ar' && <p className="text-[0.85rem] text-ink leading-relaxed m-0">{step.dua.en}</p>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/tools/hajj-umrah/data.ts
+++ b/src/tools/hajj-umrah/data.ts
@@ -1,0 +1,327 @@
+// The rites of ʿUmrah and Ḥajj, step by step. The Arabic supplications are the
+// public-domain Qur'ān/Sunnah texts; the transliteration and English meanings
+// were written for this app, not taken from any copyrighted translation. The
+// sequence follows the well-known Ḥajj at-Tamattuʿ (the form most non-residents
+// perform), and every step is tagged by its fiqh ruling so a pilgrim can filter
+// down to the essentials (arkān + wājibāt) or read the full guide with the
+// recommended (sunnah) acts. Verify with a scholar before relying on it.
+
+export type Rite = 'umrah' | 'hajj'
+export type Level = 'obligatory' | 'recommended'
+
+export interface Dua {
+  ar: string
+  translit: string
+  en: string
+}
+
+export interface Step {
+  id: string
+  rite: Rite
+  level: Level
+  /** Short fiqh ruling shown as a badge. */
+  tag: { en: string; ar: string }
+  /** Optional day/phase heading, rendered when it changes. */
+  phase?: { en: string; ar: string }
+  title: { en: string; ar: string }
+  body: { en: string; ar: string }
+  /** A supplication tied to this step ("steps and prayers"). */
+  dua?: Dua
+}
+
+const RUKN = { en: 'Pillar', ar: 'ركن' }
+const WAJIB = { en: 'Obligation', ar: 'واجب' }
+const SUNNAH = { en: 'Recommended', ar: 'سنة' }
+
+export const STEPS: Step[] = [
+  // ————————————————————————————————————— ʿUmrah —————————————————————————————————————
+  {
+    id: 'u-ghusl',
+    rite: 'umrah',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: 'At the mīqāt', ar: 'عند الميقات' },
+    title: { en: 'Prepare and make ghusl', ar: 'الاغتسال والتهيؤ' },
+    body: {
+      en: 'Before the mīqāt, bathe (ghusl) and — for men — apply perfume to the body, not to the garments. Men then wear the two white unstitched cloths (izār and ridāʾ); women wear ordinary modest clothing without a face-veil or gloves.',
+      ar: 'قبل الميقات اغتسل، ويتطيّب الرجل في بدنه لا في ثوبي إحرامه. ثم يلبس الرجل إزارًا ورداءً أبيضين، وتلبس المرأة ثيابها المعتادة الساترة من غير نقاب ولا قفّازين.',
+    },
+  },
+  {
+    id: 'u-ihram',
+    rite: 'umrah',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: 'At the mīqāt', ar: 'عند الميقات' },
+    title: { en: 'Enter iḥrām at the mīqāt', ar: 'الإحرام من الميقات' },
+    body: {
+      en: 'At the mīqāt, form the intention (niyyah) to begin ʿUmrah and enter the state of iḥrām — you may not pass the mīqāt without it. From now until you touch the Black Stone, avoid the prohibitions of iḥrām (cutting hair or nails, perfume, hunting, intimacy).',
+      ar: 'عند الميقات انوِ الدخول في نسك العمرة وأحرم — ولا يجوز تجاوز الميقات بلا إحرام. ومن الآن إلى استلام الحجر اجتنب محظورات الإحرام (قصّ الشعر والأظفار والطيب والصيد والجماع).',
+    },
+    dua: {
+      ar: 'لَبَّيْكَ اللَّهُمَّ عُمْرَةً',
+      translit: 'Labbayk Allāhumma ʿumrah',
+      en: 'Here I am, O Allah, for ʿUmrah.',
+    },
+  },
+  {
+    id: 'u-talbiyah',
+    rite: 'umrah',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: 'At the mīqāt', ar: 'عند الميقات' },
+    title: { en: 'Recite the talbiyah', ar: 'التلبية' },
+    body: {
+      en: 'Repeat the talbiyah often from the moment you enter iḥrām until you reach the Black Stone to begin ṭawāf; men raise their voices with it.',
+      ar: 'أكثِر من التلبية من حين إحرامك إلى أن تصل الحجر الأسود لبدء الطواف؛ ويرفع الرجال أصواتهم بها.',
+    },
+    dua: {
+      ar: 'لَبَّيْكَ اللَّهُمَّ لَبَّيْكَ، لَبَّيْكَ لَا شَرِيكَ لَكَ لَبَّيْكَ، إِنَّ الْحَمْدَ وَالنِّعْمَةَ لَكَ وَالْمُلْكَ، لَا شَرِيكَ لَكَ.',
+      translit: 'Labbayk Allāhumma labbayk, labbayka lā sharīka laka labbayk, inna l-ḥamda wa n-niʿmata laka wa l-mulk, lā sharīka lak.',
+      en: 'Here I am, O Allah, here I am. Here I am, You have no partner, here I am. All praise, grace and dominion are Yours; You have no partner.',
+    },
+  },
+  {
+    id: 'u-enter',
+    rite: 'umrah',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: 'At the Masjid al-Ḥarām', ar: 'في المسجد الحرام' },
+    title: { en: 'Enter the Masjid al-Ḥarām', ar: 'دخول المسجد الحرام' },
+    body: {
+      en: 'Enter with your right foot and say the du‘ā for entering the mosque.',
+      ar: 'ادخل بقدمك اليمنى وقل دعاء دخول المسجد.',
+    },
+    dua: {
+      ar: 'بِسْمِ اللَّهِ، وَالصَّلَاةُ وَالسَّلَامُ عَلَىٰ رَسُولِ اللَّهِ، اللَّهُمَّ افْتَحْ لِي أَبْوَابَ رَحْمَتِكَ.',
+      translit: 'Bismillāh, waṣ-ṣalātu was-salāmu ʿalā rasūlillāh. Allāhumma-ftaḥ lī abwāba raḥmatik.',
+      en: 'In the name of Allah; peace and blessings be upon the Messenger of Allah. O Allah, open for me the gates of Your mercy.',
+    },
+  },
+  {
+    id: 'u-tawaf',
+    rite: 'umrah',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: 'At the Masjid al-Ḥarām', ar: 'في المسجد الحرام' },
+    title: { en: 'Ṭawāf — seven circuits', ar: 'الطواف — سبعة أشواط' },
+    body: {
+      en: 'Circle the Kaʿbah seven times anticlockwise, beginning and ending at the Black Stone — kiss it, touch it, or point to it with your right hand saying “Allāhu akbar” at the start of each circuit. Men bare the right shoulder (iḍṭibāʿ) and walk briskly (raml) in the first three circuits. Between the Yemeni Corner and the Black Stone say the du‘ā below; supplicate freely otherwise.',
+      ar: 'طُف بالكعبة سبعة أشواط عكس عقارب الساعة، تبدأ وتختم عند الحجر الأسود — تُقبّله أو تستلمه أو تشير إليه بيمينك قائلًا «الله أكبر» في بداية كل شوط. ويكشف الرجل كتفه الأيمن (الاضطباع) ويرمُل في الأشواط الثلاثة الأولى. وبين الركن اليماني والحجر قل الدعاء الآتي، وادعُ بما شئت في سائره.',
+    },
+    dua: {
+      ar: 'رَبَّنَا آتِنَا فِي الدُّنْيَا حَسَنَةً وَفِي الْآخِرَةِ حَسَنَةً وَقِنَا عَذَابَ النَّارِ.',
+      translit: 'Rabbanā ātinā fī d-dunyā ḥasanah wa fī l-ākhirati ḥasanah wa qinā ʿadhāba n-nār.',
+      en: 'Our Lord, give us good in this world and good in the Hereafter, and protect us from the punishment of the Fire.',
+    },
+  },
+  {
+    id: 'u-maqam',
+    rite: 'umrah',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: 'At the Masjid al-Ḥarām', ar: 'في المسجد الحرام' },
+    title: { en: 'Two rakʿahs at the Maqām', ar: 'ركعتان عند المقام' },
+    body: {
+      en: 'After ṭawāf, pray two rakʿahs behind the Maqām of Ibrāhīm if you can, otherwise anywhere in the mosque — reciting Sūrat al-Kāfirūn in the first and al-Ikhlāṣ in the second.',
+      ar: 'بعد الطواف صلِّ ركعتين خلف مقام إبراهيم إن تيسّر، وإلا ففي أي موضع من المسجد — تقرأ في الأولى سورة الكافرون وفي الثانية الإخلاص.',
+    },
+  },
+  {
+    id: 'u-zamzam',
+    rite: 'umrah',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: 'At the Masjid al-Ḥarām', ar: 'في المسجد الحرام' },
+    title: { en: 'Drink Zamzam', ar: 'شرب ماء زمزم' },
+    body: {
+      en: 'Drink your fill of Zamzam and pour some over your head, supplicating for whatever you wish — “the water of Zamzam is for whatever it is drunk for.”',
+      ar: 'اشرب من ماء زمزم وصبَّ على رأسك، وادعُ بما شئت — «ماء زمزم لِما شُرِب له».',
+    },
+  },
+  {
+    id: 'u-saee',
+    rite: 'umrah',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: 'At Ṣafā & Marwah', ar: 'بين الصفا والمروة' },
+    title: { en: 'Saʿy between Ṣafā and Marwah', ar: 'السعي بين الصفا والمروة' },
+    body: {
+      en: 'Go to Ṣafā; as you approach recite the verse below. Climb it facing the Kaʿbah, raise your hands and proclaim the tahlīl and takbīr three times with du‘ā between. Then walk to Marwah — men jog between the two green markers — completing seven trips (Ṣafā→Marwah is one), ending at Marwah.',
+      ar: 'اذهب إلى الصفا، وعند اقترابك اقرأ الآية الآتية. ارقَ عليه مستقبلًا الكعبة وارفع يديك وكبّر وهلّل ثلاثًا وادعُ بينها. ثم امشِ إلى المروة — ويسعى الرجل بين العلمين الأخضرين — حتى تُتمّ سبعة أشواط (من الصفا إلى المروة شوط)، وتختم بالمروة.',
+    },
+    dua: {
+      ar: 'إِنَّ الصَّفَا وَالْمَرْوَةَ مِنْ شَعَائِرِ اللَّهِ… أَبْدَأُ بِمَا بَدَأَ اللَّهُ بِهِ.',
+      translit: 'Inna ṣ-ṣafā wa l-marwata min shaʿāʾirillāh… abdaʾu bimā badaʾa llāhu bih.',
+      en: 'Indeed Ṣafā and Marwah are among the symbols of Allah… I begin with what Allah began with. (al-Baqarah 2:158)',
+    },
+  },
+  {
+    id: 'u-halq',
+    rite: 'umrah',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: 'Completing ʿUmrah', ar: 'إتمام العمرة' },
+    title: { en: 'Shave or trim the hair', ar: 'الحلق أو التقصير' },
+    body: {
+      en: 'Men shave the whole head (ḥalq — more rewarded) or trim it evenly (taqṣīr); women gather their hair and trim a fingertip’s length. With this your ʿUmrah is complete and the restrictions of iḥrām are lifted.',
+      ar: 'يحلق الرجل رأسه كله (والحلق أفضل) أو يقصّره من جميع جوانبه؛ وتقصّر المرأة قدر أنملة من شعرها. وبهذا تتمّ العمرة وتحلّ محظورات الإحرام.',
+    },
+  },
+
+  // ————————————————————————————————————— Ḥajj —————————————————————————————————————
+  {
+    id: 'h-ihram',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: '8 Dhū al-Ḥijjah — Yawm at-Tarwiyah', ar: '٨ ذو الحجة — يوم التروية' },
+    title: { en: 'Enter iḥrām for Ḥajj', ar: 'الإحرام بالحج' },
+    body: {
+      en: 'On the morning of the 8th, make ghusl, put on iḥrām, and form the intention for Ḥajj — for tamattuʿ, from your lodging in Makkah. Then begin the talbiyah of Ḥajj.',
+      ar: 'صباح الثامن اغتسل والبس الإحرام وانوِ الحج — والمتمتّع يُحرم من مكانه في مكة. ثم لبِّ بالحج.',
+    },
+    dua: {
+      ar: 'لَبَّيْكَ اللَّهُمَّ حَجًّا',
+      translit: 'Labbayk Allāhumma ḥajjā',
+      en: 'Here I am, O Allah, for Ḥajj.',
+    },
+  },
+  {
+    id: 'h-mina1',
+    rite: 'hajj',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: '8 Dhū al-Ḥijjah — Yawm at-Tarwiyah', ar: '٨ ذو الحجة — يوم التروية' },
+    title: { en: 'Go to Minā', ar: 'التوجّه إلى منى' },
+    body: {
+      en: 'Head to Minā and pray Ẓuhr, ʿAṣr, Maghrib, ʿIshāʾ and the next Fajr there — each four-unit prayer shortened to two (qaṣr) but not combined — staying the night of the 8th.',
+      ar: 'اذهب إلى منى وصلِّ بها الظهر والعصر والمغرب والعشاء وفجر التاسع — تقصر الرباعية إلى ركعتين من غير جمع — وبِت بها ليلة الثامن.',
+    },
+  },
+  {
+    id: 'h-arafah',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: '9 Dhū al-Ḥijjah — Yawm ʿArafah', ar: '٩ ذو الحجة — يوم عرفة' },
+    title: { en: 'Stand at ʿArafah', ar: 'الوقوف بعرفة' },
+    body: {
+      en: 'After sunrise move towards ʿArafah. From the sun’s zenith combine and shorten Ẓuhr and ʿAṣr (two units each), then devote the afternoon to du‘ā and dhikr facing the qiblah with raised hands until sunset. “Ḥajj is ʿArafah.” Remaining until sunset is obligatory.',
+      ar: 'بعد شروق التاسع اتجه إلى عرفة. ومن الزوال اجمع واقصر الظهر والعصر (ركعتين ركعتين)، ثم اجتهد بقية النهار بالدعاء والذكر مستقبلًا القبلة رافعًا يديك إلى الغروب. «الحج عرفة». والبقاء إلى الغروب واجب.',
+    },
+    dua: {
+      ar: 'لَا إِلَٰهَ إِلَّا اللَّهُ وَحْدَهُ لَا شَرِيكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ وَهُوَ عَلَىٰ كُلِّ شَيْءٍ قَدِيرٌ.',
+      translit: 'Lā ilāha illā llāhu waḥdahu lā sharīka lah, lahu l-mulku wa lahu l-ḥamd, wa huwa ʿalā kulli shayʾin qadīr.',
+      en: 'There is no god but Allah alone, with no partner; His is the dominion and His the praise, and He is able to do all things. (the best du‘ā of ʿArafah)',
+    },
+  },
+  {
+    id: 'h-muzdalifah',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: 'Night of the 10th — Muzdalifah', ar: 'ليلة العاشر — مزدلفة' },
+    title: { en: 'Night at Muzdalifah', ar: 'المبيت بمزدلفة' },
+    body: {
+      en: 'After sunset go to Muzdalifah — do not pray Maghrib on the way — and there pray Maghrib and ʿIshāʾ combined (Maghrib three units, ʿIshāʾ two). Stay the night; the weak and women may leave after midnight. Pray Fajr early, supplicate, and gather pebbles for the stoning.',
+      ar: 'بعد الغروب اذهب إلى مزدلفة — ولا تصلِّ المغرب في الطريق — وصلِّ بها المغرب والعشاء جمعًا (المغرب ثلاثًا والعشاء ركعتين). وبِت بها، ويجوز للضعفة والنساء الدفع بعد منتصف الليل. صلِّ الفجر مبكرًا وادعُ، والتقط حصى الجمار.',
+    },
+  },
+  {
+    id: 'h-jamra-aqaba',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: '10 Dhū al-Ḥijjah — Yawm an-Naḥr', ar: '١٠ ذو الحجة — يوم النحر' },
+    title: { en: 'Stone Jamrat al-ʿAqabah', ar: 'رمي جمرة العقبة' },
+    body: {
+      en: 'On the morning of the 10th go to the large Jamrah (al-ʿAqabah) and throw seven pebbles one by one, saying “Allāhu akbar” with each. Stop the talbiyah as you throw the first pebble.',
+      ar: 'صباح العاشر ارمِ جمرة العقبة الكبرى بسبع حصيات واحدة تلو الأخرى، مكبّرًا مع كل حصاة. وتقطع التلبية مع أول حصاة.',
+    },
+  },
+  {
+    id: 'h-hady',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: '10 Dhū al-Ḥijjah — Yawm an-Naḥr', ar: '١٠ ذو الحجة — يوم النحر' },
+    title: { en: 'Offer the sacrifice (hady)', ar: 'ذبح الهدي' },
+    body: {
+      en: 'Those performing tamattuʿ or qirān offer a sacrifice — usually arranged through a licensed agency — in gratitude for joining the two rites.',
+      ar: 'يذبح المتمتّع والقارن هديًا — غالبًا عبر جهة مرخّصة — شكرًا للجمع بين النسكين.',
+    },
+  },
+  {
+    id: 'h-halq',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: '10 Dhū al-Ḥijjah — Yawm an-Naḥr', ar: '١٠ ذو الحجة — يوم النحر' },
+    title: { en: 'Shave or trim the hair', ar: 'الحلق أو التقصير' },
+    body: {
+      en: 'Men shave (ḥalq — more rewarded) or trim (taqṣīr); women trim a fingertip’s length. After stoning and shaving comes the first release (at-taḥallul al-awwal): everything becomes lawful again except intimacy with one’s spouse.',
+      ar: 'يحلق الرجل (والحلق أفضل) أو يقصّر؛ وتقصّر المرأة قدر أنملة. وبعد الرمي والحلق يحصل التحلّل الأول: فيحلّ كل شيء إلا الجماع.',
+    },
+  },
+  {
+    id: 'h-ifadah',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: RUKN,
+    phase: { en: '10 Dhū al-Ḥijjah — Yawm an-Naḥr', ar: '١٠ ذو الحجة — يوم النحر' },
+    title: { en: 'Ṭawāf al-Ifāḍah and Saʿy', ar: 'طواف الإفاضة والسعي' },
+    body: {
+      en: 'Go to the Kaʿbah for Ṭawāf al-Ifāḍah — a pillar of Ḥajj — followed by saʿy between Ṣafā and Marwah (for tamattuʿ). With this comes the final release (at-taḥallul ath-thānī) and every restriction lifts. It may be delayed into the days of Minā.',
+      ar: 'اذهب إلى الكعبة لطواف الإفاضة — وهو ركن الحج — يليه السعي بين الصفا والمروة (للمتمتّع). وبه يحصل التحلّل الثاني فيحلّ كل شيء. ويجوز تأخيره إلى أيام منى.',
+    },
+  },
+  {
+    id: 'h-mina-nights',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: '11–13 Dhū al-Ḥijjah — Ayyām at-Tashrīq', ar: '١١–١٣ ذو الحجة — أيام التشريق' },
+    title: { en: 'Nights and stoning at Minā', ar: 'المبيت والرمي بمنى' },
+    body: {
+      en: 'Spend the nights of the 11th, 12th (and 13th) at Minā. Each day, after the sun passes its zenith, stone the three Jamarāt in order — the small (aṣ-Ṣughrā), then the middle (al-Wusṭā), then the large (al-ʿAqabah) — seven pebbles at each with takbīr.',
+      ar: 'بِت ليالي الحادي عشر والثاني عشر (والثالث عشر) بمنى. وارمِ كل يوم بعد الزوال الجمرات الثلاث بالترتيب — الصغرى ثم الوسطى ثم الكبرى — سبع حصيات لكل جمرة مع التكبير.',
+    },
+  },
+  {
+    id: 'h-tashriq-dua',
+    rite: 'hajj',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: '11–13 Dhū al-Ḥijjah — Ayyām at-Tashrīq', ar: '١١–١٣ ذو الحجة — أيام التشريق' },
+    title: { en: 'Supplicate after the first two Jamarāt', ar: 'الدعاء بعد الجمرتين' },
+    body: {
+      en: 'After stoning the small Jamrah and again after the middle one, step aside, face the qiblah and make long du‘ā with raised hands. There is no standing for du‘ā after the large Jamrah.',
+      ar: 'بعد رمي الجمرة الصغرى ثم الوسطى، تنحَّ واستقبل القبلة وأطِل الدعاء رافعًا يديك. ولا وقوف للدعاء بعد الجمرة الكبرى.',
+    },
+  },
+  {
+    id: 'h-nafr',
+    rite: 'hajj',
+    level: 'recommended',
+    tag: SUNNAH,
+    phase: { en: '11–13 Dhū al-Ḥijjah — Ayyām at-Tashrīq', ar: '١١–١٣ ذو الحجة — أيام التشريق' },
+    title: { en: 'Leaving Minā (12th or 13th)', ar: 'النفر من منى' },
+    body: {
+      en: 'You may hasten and leave after stoning on the 12th before sunset (an-nafr al-awwal), or stay for the 13th and stone once more (an-nafr ath-thānī) — staying the extra day is better.',
+      ar: 'يجوز أن تتعجّل فتنفر بعد رمي الثاني عشر قبل الغروب (النفر الأول)، أو تبقى للثالث عشر وترمي (النفر الثاني) — والبقاء أفضل.',
+    },
+  },
+  {
+    id: 'h-wada',
+    rite: 'hajj',
+    level: 'obligatory',
+    tag: WAJIB,
+    phase: { en: 'Before leaving Makkah', ar: 'قبل مغادرة مكة' },
+    title: { en: 'Farewell Ṭawāf (al-Wadāʿ)', ar: 'طواف الوداع' },
+    body: {
+      en: 'Before leaving Makkah, make a farewell ṭawāf of seven circuits so that the last of your acts is at the House. It is waived for a menstruating woman.',
+      ar: 'قبل مغادرة مكة طُف طواف الوداع سبعة أشواط ليكون آخر عهدك بالبيت. ويسقط عن الحائض.',
+    },
+  },
+]

--- a/src/tools/hajj-umrah/meta.ts
+++ b/src/tools/hajj-umrah/meta.ts
@@ -1,0 +1,23 @@
+import { lazyTool } from '../../lib/lazyTool'
+import type { Tool } from '../types'
+import { KaabaIcon } from '../../components/icons'
+
+export const hajjUmrahTool: Tool = {
+  id: 'hajj-umrah',
+  name: 'Hajj & Umrah Guide',
+  nameAr: 'دليل الحج والعمرة',
+  tagline: 'The rites step by step, with the duas and a tracker.',
+  description:
+    'A step-by-step guide to ʿUmrah and Ḥajj — every act with its supplication and its fiqh ruling. Switch between ʿUmrah (default) and Ḥajj, filter to just the pillars and duties or read the full guide with the recommended sunan, and tap each step to track your progress. Fully offline.',
+  category: 'Saudi / Local',
+  keywords: ['hajj', 'umrah', 'pilgrimage', 'manasik', 'ihram', 'tawaf', 'saee', 'arafah', 'guide', 'حج', 'عمرة', 'مناسك', 'إحرام', 'طواف', 'سعي', 'عرفة'],
+  status: 'stable',
+  Icon: KaabaIcon,
+  component: lazyTool(() => import('./HajjUmrahTool')),
+  ar: {
+    name: 'دليل الحج والعمرة',
+    tagline: 'المناسك خطوةً بخطوة، مع الأدعية وعدّاد تقدّم.',
+    description:
+      'دليل خطوةً بخطوة لأداء العمرة والحج — كل عمل مع دعائه وحكمه الفقهي. بدّل بين العمرة (الافتراضية) والحج، واعرض الأركان والواجبات فقط أو الدليل كاملًا مع السنن، واضغط كل خطوة لتتبّع تقدّمك. يعمل دون اتصال.',
+  },
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { hijriCalendarTool } from './hijri-calendar/meta'
 import { islamicCalendarTool } from './islamic-calendar/meta'
 import { istikharaTool } from './istikhara/meta'
 import { adhkarTool } from './adhkar/meta'
+import { hajjUmrahTool } from './hajj-umrah/meta'
 import { hisnAlMuslimTool } from './hisn-al-muslim/meta'
 import { ibanValidatorTool } from './iban-validator/meta'
 import { tafqeetTool } from './tafqeet/meta'
@@ -179,6 +180,7 @@ export const tools: Tool[] = [
   prayerTimesTool,
   islamicCalendarTool,
   adhkarTool,
+  hajjUmrahTool,
   hisnAlMuslimTool,
   istikharaTool,
   hijriCalendarTool,


### PR DESCRIPTION
Closes #236.

A step-by-step manāsik guide for ʿUmrah and Ḥajj — the interactive app the issue asked for, not a static page.

## What it does
- **ʿUmrah / Ḥajj mode switcher** — ʿUmrah by default; switching rites loads that rite's own saved progress.
- **Obligatory vs Recommended switcher** — *Obligatory* narrows to just the arkān + wājibāt; *Recommended* shows the full guide with the sunan woven in. Each step also carries a ruling badge (Pillar / Obligation / Recommended).
- **Progress bars (the morning/evening adhkār pattern)** — each step is a tap-to-complete card with a checkbox; an edge-docked completion bar tracks steps done / total, each day/phase heading shows its own count, and progress persists per rite in `localStorage` (with a reset).
- **Steps *and* prayers** — every relevant step carries its supplication (talbiyah, iḥrām intention, the ṭawāf and ʿArafah duʿās, Ṣafā/Marwah, …) in vocalised Arabic with transliteration + meaning and a copy button. Ḥajj is laid out day-by-day (Tarwiyah → ʿArafah → Muzdalifah → Naḥr → Tashrīq → farewell ṭawāf), following the tamattuʿ form.
- Fully bilingual AR/EN, offline, client-side.

## Sources (KSA-aligned)
The fiqh classifications follow the manāsik of Shaykh Ibn Bāz and the Permanent Committee for Ifta; the procedure follows the Saudi Ministry of Ḥajj & ʿUmrah. Confirmed against those rulings (e.g. saʿy as a pillar of both rites). The app surfaces a bilingual **Sources** list and a disclaimer naming the authorities.

## Wiring
New `KaabaIcon`, registered in the catalog under Saudi / Local, SEO entry + sitemap URLs (both locales prerendered), and an e2e case covering the rite switch, level filter, and tap-to-complete.

`typecheck` clean · `build` clean (103 prerendered pages) · e2e case passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzQELMWECyPnTUhZUBTYku

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzQELMWECyPnTUhZUBTYku)_