### PR TITLE
Fix border-width layout shift on completed step/dhikr cards

### DIFF
--- a/src/tools/adhkar/AdhkarTool.tsx
+++ b/src/tools/adhkar/AdhkarTool.tsx
@@ -146,9 +146,9 @@ export default function AdhkarTool() {
           const pct = Math.min(100, Math.round((cur / d.count) * 100))
           return (
             <li key={d.id}>
-              {/* The whole card is the counter — tap it to count one. Not-done
-                  carries a prominent 2px border (still to do); once complete it
-                  drops to the plain 1px static border. */}
+              {/* The whole card is the counter — tap it to count one. The border
+                  stays a constant 2px and only its colour changes on completion
+                  (prominent green → soft line) so nothing shifts when it's done. */}
               <div
                 role="button"
                 tabIndex={0}
@@ -156,7 +156,7 @@ export default function AdhkarTool() {
                 aria-label={`${d.translit || d.en} — ${s.progress(cur, d.count)}`}
                 onClick={() => tap(d.id, d.count)}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); tap(d.id, d.count) } }}
-                className={`rounded-md bg-[var(--surface)] p-4 flex flex-col gap-3 cursor-pointer select-none transition-[border-color,opacity] duration-150 ${done ? 'border border-[color:var(--line-soft)] opacity-70' : 'border-2 border-green-600'}`}
+                className={`rounded-md bg-[var(--surface)] p-4 flex flex-col gap-3 cursor-pointer select-none border-2 transition-[border-color,opacity] duration-150 ${done ? 'border-[color:var(--line-soft)] opacity-70' : 'border-green-600'}`}
               >
                 <div className="flex items-center justify-end">
                   <span className="text-[0.75rem] font-semibold text-ink-faint tabular-nums">{s.times(d.count)}</span>

--- a/src/tools/hajj-umrah/HajjUmrahTool.tsx
+++ b/src/tools/hajj-umrah/HajjUmrahTool.tsx
@@ -200,7 +200,7 @@ function StepCard({ step, done, onToggle, locale, s }: {
       aria-label={step.title[locale]}
       onClick={onToggle}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle() } }}
-      className={`rounded-md bg-[var(--surface)] p-4 flex flex-col gap-3 cursor-pointer select-none transition-[border-color,opacity] duration-150 ${done ? 'border border-[color:var(--line-soft)] opacity-60' : 'border-2 border-green-600'}`}
+      className={`rounded-md bg-[var(--surface)] p-4 flex flex-col gap-3 cursor-pointer select-none border-2 transition-[border-color,opacity] duration-150 ${done ? 'border-[color:var(--line-soft)] opacity-60' : 'border-green-600'}`}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2.5 min-w-0">


### PR DESCRIPTION
Follow-up to #237.

Completing a card shifted the layout by a pixel: the card dropped from a **2px** border to a **1px** border when marked done. Now the border stays a constant **2px** and only its **colour** animates (green → soft line), so nothing moves.

Applies to both the new **Hajj & Umrah** step cards and — as reported — the **morning/evening adhkār** cards, which had the same, smaller shift.

`typecheck` clean · `build` clean · adhkar + hajj-umrah e2e cases passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzQELMWECyPnTUhZUBTYku

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzQELMWECyPnTUhZUBTYku)_