### PR TITLE
Add privacy-first analytics tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5312,6 +5312,14 @@ from the URL) to make that a config flip, not a rewrite. Trend home toward a
   so "users" inflates and returning-visitor metrics are meaningless; page/event
   counts and traffic sources are unaffected. There is therefore no cookie banner.
   `e2e/app.spec.ts` asserts no `_ga*` cookie is ever set.
+  **A second, privacy-first analytics also runs** (a Plausible-style `defer`
+  script from `analytics.ali-web-services.com`, `data-site` in `index.html`).
+  It is cookieless and its page-view beacon carries no user content — but it
+  POSTs a body to a third-party origin, so **it is allowlisted in the `ANALYTICS`
+  regex in `e2e/privacy.spec.ts`** (which asserts no OTHER origin ever receives a
+  request body, and that this one never carries typed text). Adding any further
+  analytics/beacon host means extending that regex too, or the privacy suite goes
+  red. It is disclosed in `PrivacyPage.tsx` (both locales) alongside GA.
 - **Search:** Google Search Console (domain property, DNS-verified) and Bing
   Webmaster Tools (DNS-verified); both have the sitemap submitted.
 - **Prayer alert backend** (`functions/`, our first backend): Cloud Functions gen2

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -22,7 +22,7 @@ import { PDFDocument, StandardFonts } from 'pdf-lib'
 // token, because "we do not upload your file" and "we count page views" are
 // different claims and only one of them is being tested here.
 
-const ANALYTICS = /googletagmanager\.com|google-analytics\.com|analytics\.google\.com/
+const ANALYTICS = /googletagmanager\.com|google-analytics\.com|analytics\.google\.com|analytics\.ali-web-services\.com/
 
 const TOKEN = `bis-privacy-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 

--- a/index.html
+++ b/index.html
@@ -76,6 +76,9 @@
         allow_ad_personalization_signals: false,
       });
     </script>
+
+    <!-- Privacy-first, cookieless page analytics (self-hosted) -->
+    <script defer src="https://analytics.ali-web-services.com/a.js" data-site="avIqkOVEFqXFjv72EUCP"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -85,6 +85,7 @@ const STR: Record<'en' | 'ar', { title: string; updated: string; intro: string; 
         p: [
           'We use Google Analytics (GA4) to understand aggregate usage — which tools are used and roughly where visitors come from. We do not use it to identify you and we do not sell analytics data.',
           'It runs in cookieless mode: Analytics is configured with client storage switched off, so it sets no cookies and stores no identifier in your browser. Each visit is counted on its own, and there is nothing left behind to recognise you on your next one. We also disable Google Signals and ad personalisation, and IP addresses are anonymised.',
+          'We also use a second, privacy-focused analytics service (analytics.ali-web-services.com) for the same aggregate page-view counts. It runs without cookies too, sends no personal data, and stores no identifier in your browser.',
           'Because of this, the site sets no analytics cookies at all — so there is no cookie banner to click, and nothing to opt out of.',
         ],
       },
@@ -177,6 +178,7 @@ const STR: Record<'en' | 'ar', { title: string; updated: string; intro: string; 
         p: [
           'نستخدم Google Analytics (GA4) لفهم الاستخدام الإجمالي — أي الأدوات تُستخدم ومن أين يأتي الزوار تقريبًا. لا نستخدمه للتعرّف عليك ولا نبيع بيانات التحليلات.',
           'ويعمل بوضع بلا كوكيز: أُوقفنا تخزين البيانات في المتصفح، فلا يضع أي كوكي ولا يحفظ أي معرّف لديك. تُحتسب كل زيارة على حدة، ولا يبقى شيء يتعرّف عليك في زيارتك القادمة. كما عطّلنا Google Signals وتخصيص الإعلانات، وتُخفى عناوين IP.',
+          'كما نستخدم خدمة تحليلات ثانية تُعنى بالخصوصية (analytics.ali-web-services.com) لأغراض احتساب مشاهدات الصفحات الإجمالية نفسها. وهي أيضًا تعمل بلا كوكيز، ولا تُرسل أي بيانات شخصية، ولا تحفظ أي معرّف في متصفحك.',
           'ولهذا لا يضع الموقع أي كوكيز تحليلات إطلاقًا — فلا يوجد إشعار كوكيز تضغط عليه، ولا شيء تنسحب منه.',
         ],
       },


### PR DESCRIPTION
Adds a cookieless, self-hosted analytics script (`analytics.ali-web-services.com`) alongside GA4.

## Changes
- **`index.html`** — the `defer` tracking script inside `<head>`, after the GA4 block.
- **`e2e/privacy.spec.ts`** — added the new host to the `ANALYTICS` allowlist. Necessary, not cosmetic: the privacy suite asserts *no request with a body reaches any non-analytics origin*, and this Plausible-style beacon POSTs a page-view event — so without the entry the suite (which backs the "your files are never uploaded" claim on 100+ tool pages) would go red. The `analytics never carries what you typed` test now also covers this origin.
- **`src/pages/PrivacyPage.tsx`** — disclosed the second provider in both EN and AR, since the page previously implied GA4 was the only analytics.
- **`CLAUDE.md`** — recorded the provider and the allowlist rule in the infrastructure map.

## Verification
- `npm run typecheck` passes clean.
- The `_ga` cookie test is unaffected (this provider is cookieless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1XhronVhJsJ7jVuWEfSzH)_